### PR TITLE
将策略分流的逻辑移到filter，进行了代码上的小重构。

### DIFF
--- a/cat-core/src/main/java/com/dianping/cat/abtest/ABTest.java
+++ b/cat-core/src/main/java/com/dianping/cat/abtest/ABTest.java
@@ -1,7 +1,8 @@
 package com.dianping.cat.abtest;
 
 public interface ABTest {
-	public ABTestId getTestId();
+
+	public int getTestId();
 
 	public boolean isDefaultGroup();
 
@@ -16,5 +17,49 @@ public interface ABTest {
 	public boolean isGroupE();
 
 	public boolean isGroup(String name);
+
+	/** A default ABTest which id is 0 and group is default */
+	public static final ABTest DEFAULT = new ABTest() {
+
+		@Override
+		public boolean isGroupE() {
+			return false;
+		}
+
+		@Override
+		public boolean isGroupD() {
+			return false;
+		}
+
+		@Override
+		public boolean isGroupC() {
+			return false;
+		}
+
+		@Override
+		public boolean isGroupB() {
+			return false;
+		}
+
+		@Override
+		public boolean isGroupA() {
+			return false;
+		}
+
+		@Override
+		public boolean isGroup(String name) {
+			return false;
+		}
+
+		@Override
+		public boolean isDefaultGroup() {
+			return true;
+		}
+
+		@Override
+		public int getTestId() {
+			return 0;
+		}
+	};
 
 }

--- a/cat-core/src/main/java/com/dianping/cat/abtest/ABTestManager.java
+++ b/cat-core/src/main/java/com/dianping/cat/abtest/ABTestManager.java
@@ -4,16 +4,15 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.unidal.lookup.ContainerLoader;
 
-import com.dianping.cat.abtest.internal.DefaultABTest;
+import com.dianping.cat.abtest.spi.ABTestContext;
 import com.dianping.cat.abtest.spi.ABTestContextManager;
 
 public final class ABTestManager {
 	private static ABTestContextManager s_contextManager;
 
 	public static ABTest getTest(ABTestId id) {
-		initialize();
-
-		return new DefaultABTest(id, s_contextManager);
+		ABTestContext ctx = s_contextManager.getContext(id);
+		return ctx.getABTest();
 	}
 
 	public static void initialize() {
@@ -29,12 +28,14 @@ public final class ABTestManager {
 				}
 			}
 		}
+
 	}
 
 	public static void onRequestBegin(HttpServletRequest req) {
 		initialize();
 
 		s_contextManager.onRequestBegin(req);
+
 	}
 
 	public static void onRequestEnd() {

--- a/cat-core/src/main/java/com/dianping/cat/abtest/internal/DefaultABTest.java
+++ b/cat-core/src/main/java/com/dianping/cat/abtest/internal/DefaultABTest.java
@@ -1,29 +1,26 @@
 package com.dianping.cat.abtest.internal;
 
 import com.dianping.cat.abtest.ABTest;
-import com.dianping.cat.abtest.ABTestId;
 import com.dianping.cat.abtest.spi.ABTestContext;
-import com.dianping.cat.abtest.spi.ABTestContextManager;
 
 public class DefaultABTest implements ABTest {
-	private ABTestContextManager m_contextManager;
 
-	private ABTestId m_id;
+	private int m_id;
 
-	public DefaultABTest(ABTestId id, ABTestContextManager contextManager) {
-		m_contextManager = contextManager;
+	private String m_groupName;
+
+	public DefaultABTest(int id, String groupName) {
 		m_id = id;
+		m_groupName = groupName;
 	}
 
 	@Override
-	public ABTestId getTestId() {
+	public int getTestId() {
 		return m_id;
 	}
 
 	private String getGroupName() {
-		ABTestContext ctx = m_contextManager.getContext(m_id);
-
-		return ctx.getGroupName();
+		return m_groupName;
 	}
 
 	@Override

--- a/cat-core/src/main/java/com/dianping/cat/abtest/spi/ABTestContext.java
+++ b/cat-core/src/main/java/com/dianping/cat/abtest/spi/ABTestContext.java
@@ -2,14 +2,16 @@ package com.dianping.cat.abtest.spi;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.dianping.cat.abtest.ABTest;
+
 public interface ABTestContext {
 	public final String DEFAULT_GROUP = "default";
 
 	public ABTestEntity getEntity();
 
-	public String getGroupName();
-
 	public void setGroupName(String groupName);
 
 	public HttpServletRequest getHttpServletRequest();
+
+	public ABTest getABTest();
 }

--- a/cat-core/src/main/java/com/dianping/cat/abtest/spi/ABTestEntity.java
+++ b/cat-core/src/main/java/com/dianping/cat/abtest/spi/ABTestEntity.java
@@ -16,11 +16,11 @@ public class ABTestEntity {
 	}
 
 	public String getGroupStrategy() {
-		return m_entity.getGroupStrategy().getName();
+		return m_entity.getGroupStrategy() != null ? m_entity.getGroupStrategy().getName() : null;
 	}
 
 	public String getGroupStrategyConfiguration() {
-		return m_entity.getGroupStrategy().getConfiguration();
+		return m_entity.getGroupStrategy() != null ? m_entity.getGroupStrategy().getConfiguration() : null;
 	}
 
 	public int getId() {
@@ -32,7 +32,7 @@ public class ABTestEntity {
 	}
 
 	public boolean isEligible(Date date) {
-		if (m_entity.getDisabled()) {
+		if (m_entity.getDisabled() != null && m_entity.getDisabled()) {
 			return false;
 		}
 
@@ -62,11 +62,15 @@ public class ABTestEntity {
 	}
 
 	public void setGroupStrategy(String groupStrategy) {
-		m_entity.getGroupStrategy().setName(groupStrategy);
+		if (m_entity.getGroupStrategy() != null) {
+			m_entity.getGroupStrategy().setName(groupStrategy);
+		}
 	}
 
 	public void setGroupStrategyConfiguration(String groupStrategyConfiguration) {
-		m_entity.getGroupStrategy().setConfiguration(groupStrategyConfiguration);
+		if (m_entity.getGroupStrategy() != null) {
+			m_entity.getGroupStrategy().setConfiguration(groupStrategyConfiguration);
+		}
 	}
 
 	public void setId(int id) {

--- a/cat-core/src/main/java/com/dianping/cat/abtest/spi/ABTestEntityManager.java
+++ b/cat-core/src/main/java/com/dianping/cat/abtest/spi/ABTestEntityManager.java
@@ -1,7 +1,7 @@
 package com.dianping.cat.abtest.spi;
 
-import com.dianping.cat.abtest.ABTestId;
+import java.util.Map;
 
 public interface ABTestEntityManager {
-	public ABTestEntity getEntity(ABTestId id);
+	public Map<Integer, ABTestEntity> getEntities();
 }

--- a/cat-core/src/main/java/com/dianping/cat/abtest/spi/internal/DefaultABTestContext.java
+++ b/cat-core/src/main/java/com/dianping/cat/abtest/spi/internal/DefaultABTestContext.java
@@ -1,57 +1,26 @@
 package com.dianping.cat.abtest.spi.internal;
 
-import java.util.Date;
-
 import javax.servlet.http.HttpServletRequest;
 
-import com.dianping.cat.Cat;
+import com.dianping.cat.abtest.ABTest;
+import com.dianping.cat.abtest.internal.DefaultABTest;
 import com.dianping.cat.abtest.spi.ABTestContext;
 import com.dianping.cat.abtest.spi.ABTestEntity;
-import com.dianping.cat.abtest.spi.ABTestGroupStrategy;
-import com.dianping.cat.message.Message;
-import com.dianping.cat.message.Transaction;
 
 public class DefaultABTestContext implements ABTestContext {
-	private String m_groupName = DEFAULT_GROUP;
 
-	private ABTestEntity m_entity;
+	private final ABTestEntity m_entity;
 
 	private HttpServletRequest m_req;
 
-	private ABTestGroupStrategy m_groupStrategy;
+	private ABTest m_abTest = ABTest.DEFAULT;
 
-	private boolean m_applied;
+	public DefaultABTestContext() {
+		m_entity = new ABTestEntity();
+	}
 
 	public DefaultABTestContext(ABTestEntity entity) {
 		m_entity = entity;
-	}
-
-	@Override
-	public String getGroupName() {
-		if (m_entity.isEligible(new Date())) {
-			if (!m_applied) {
-				Transaction t = Cat.newTransaction("GroupStrategy", m_entity.getGroupStrategy());
-
-				try {
-					m_groupStrategy.apply(this);
-
-					t.setStatus(Message.SUCCESS);
-				} catch (Throwable e) {
-					t.setStatus(e);
-					Cat.logError(e);
-				} finally {
-					t.complete();
-					m_applied = true;
-				}
-			}
-		}
-
-		return m_groupName;
-	}
-
-	@Override
-	public void setGroupName(String groupName) {
-		m_groupName = groupName;
 	}
 
 	public void setup(HttpServletRequest req) {
@@ -68,7 +37,14 @@ public class DefaultABTestContext implements ABTestContext {
 		return m_entity;
 	}
 
-	public void setGroupStrategy(ABTestGroupStrategy groupStrategy) {
-		m_groupStrategy = groupStrategy;
+	@Override
+	public ABTest getABTest() {
+		return m_abTest;
 	}
+
+	@Override
+	public void setGroupName(String groupName) {
+		m_abTest = new DefaultABTest(m_entity.getId(), groupName);
+	}
+
 }

--- a/cat-core/src/main/java/com/dianping/cat/abtest/spi/internal/DefaultABTestContextManager.java
+++ b/cat-core/src/main/java/com/dianping/cat/abtest/spi/internal/DefaultABTestContextManager.java
@@ -1,5 +1,6 @@
 package com.dianping.cat.abtest.spi.internal;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -8,12 +9,15 @@ import javax.servlet.http.HttpServletRequest;
 import org.unidal.lookup.ContainerHolder;
 import org.unidal.lookup.annotation.Inject;
 
+import com.dianping.cat.Cat;
 import com.dianping.cat.abtest.ABTestId;
 import com.dianping.cat.abtest.spi.ABTestContext;
 import com.dianping.cat.abtest.spi.ABTestContextManager;
 import com.dianping.cat.abtest.spi.ABTestEntity;
 import com.dianping.cat.abtest.spi.ABTestEntityManager;
 import com.dianping.cat.abtest.spi.ABTestGroupStrategy;
+import com.dianping.cat.message.Message;
+import com.dianping.cat.message.Transaction;
 
 public class DefaultABTestContextManager extends ContainerHolder implements ABTestContextManager {
 	@Inject
@@ -33,18 +37,10 @@ public class DefaultABTestContextManager extends ContainerHolder implements ABTe
 		int id = testId.getValue();
 		DefaultABTestContext ctx = map.get(id);
 
+		// 如果ctx不存在，返回默认的DefaultABTestContext
 		if (ctx == null) {
-			ABTestEntity entity = m_entityManager.getEntity(testId);
-
-			ctx = new DefaultABTestContext(entity);
-
-			if (!entity.isDisabled()) {
-				ABTestGroupStrategy groupStrategy = lookup(ABTestGroupStrategy.class, entity.getGroupStrategy());
-
-				ctx.setup(entry.getHttpServletRequest());
-				ctx.setGroupStrategy(groupStrategy);
-			}
-
+			ctx = new DefaultABTestContext();
+			// 把ctx保存起来, 如果在同一个请球内多次调用该方法，则都返回该DefaultABTestContext
 			map.put(id, ctx);
 		}
 
@@ -59,30 +55,45 @@ public class DefaultABTestContextManager extends ContainerHolder implements ABTe
 	@Override
 	public void onRequestBegin(HttpServletRequest req) {
 		Entry entry = m_threadLocal.get();
-
-		entry.setHttpServletRequest(req);
-
 		Map<Integer, DefaultABTestContext> map = entry.getContextMap();
-		for (DefaultABTestContext ctx : map.values()) {
+
+		// 获取所有的ABTestEntity
+		Map<Integer, ABTestEntity> entities = m_entityManager.getEntities();
+		// 遍历所有Entity，每个Entity都计算其分流结果，并设置到ctx中
+		for (ABTestEntity entity : entities.values()) {
+			DefaultABTestContext ctx = new DefaultABTestContext(entity);
+
 			ctx.setup(req);
+
+			if (!entity.isDisabled()) {
+				if (entity.isEligible(new Date())) {
+					Transaction t = Cat.newTransaction("GroupStrategy", entity.getGroupStrategy());
+					ABTestGroupStrategy groupStrategy = lookup(ABTestGroupStrategy.class, entity.getGroupStrategy());
+					try {
+						// 计算分流结果
+						groupStrategy.apply(ctx);
+
+						t.setStatus(Message.SUCCESS);
+					} catch (Throwable e) {
+						t.setStatus(e);
+						Cat.logError(e);
+					} finally {
+						t.complete();
+					}
+				}
+			}
+			// 将ctx保存到当前的Threadlocal中
+			map.put(entity.getId(), ctx);
 		}
+
 	}
 
 	static class Entry {
 		private Map<Integer, DefaultABTestContext> m_map = new HashMap<Integer, DefaultABTestContext>(4);
 
-		private HttpServletRequest m_req;
-
 		public Map<Integer, DefaultABTestContext> getContextMap() {
 			return m_map;
 		}
 
-		public HttpServletRequest getHttpServletRequest() {
-			return m_req;
-		}
-
-		public void setHttpServletRequest(HttpServletRequest req) {
-			m_req = req;
-		}
 	}
 }

--- a/cat-core/src/main/java/com/dianping/cat/abtest/spi/internal/DefaultABTestEntityManager.java
+++ b/cat-core/src/main/java/com/dianping/cat/abtest/spi/internal/DefaultABTestEntityManager.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
 
-import com.dianping.cat.abtest.ABTestId;
 import com.dianping.cat.abtest.model.entity.Abtest;
 import com.dianping.cat.abtest.model.entity.Entity;
 import com.dianping.cat.abtest.model.transform.BaseVisitor;
@@ -17,20 +16,6 @@ import com.dianping.cat.abtest.spi.ABTestEntityManager;
 
 public class DefaultABTestEntityManager implements ABTestEntityManager, Initializable {
 	private Map<Integer, ABTestEntity> m_entities = new HashMap<Integer, ABTestEntity>();
-
-	@Override
-	public ABTestEntity getEntity(ABTestId id) {
-		ABTestEntity entity = m_entities.get(id.getValue());
-
-		if (entity == null) {
-			entity = new ABTestEntity();
-			entity.setDisabled(true);
-
-			m_entities.put(id.getValue(), entity);
-		}
-
-		return entity;
-	}
 
 	@Override
 	public void initialize() throws InitializationException {
@@ -58,5 +43,10 @@ public class DefaultABTestEntityManager implements ABTestEntityManager, Initiali
 
 			m_entities.put(abTestEntity.getId(), abTestEntity);
 		}
+	}
+
+	@Override
+	public Map<Integer, ABTestEntity> getEntities() {
+		return m_entities;
 	}
 }

--- a/cat-core/src/test/java/com/dianping/cat/abtest/demo/roundrobin/SimpleRoundRobinServlet.java
+++ b/cat-core/src/test/java/com/dianping/cat/abtest/demo/roundrobin/SimpleRoundRobinServlet.java
@@ -14,10 +14,9 @@ import com.dianping.cat.abtest.sample.SampleTest.MyABTestId;
 public class SimpleRoundRobinServlet extends HttpServlet {
 	private static final long serialVersionUID = -6472784609174835547L;
 
-	private ABTest m_abtest = ABTestManager.getTest(MyABTestId.CASE1);
-
 	@Override
 	public void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		ABTest m_abtest = ABTestManager.getTest(MyABTestId.CASE1);
 		if (m_abtest.isGroupA()) {
 			String a = "This is group A";
 			byte[] aByte = a.getBytes();
@@ -29,7 +28,7 @@ public class SimpleRoundRobinServlet extends HttpServlet {
 			response.getOutputStream().write(bByte);
 			// Cat.logMetric(...);
 		} else {
-			String b = "This is group dfault";
+			String b = "This is group default";
 			byte[] bByte = b.getBytes();
 			response.getOutputStream().write(bByte);
 			// Cat.logMetric(...);

--- a/cat-core/src/test/java/com/dianping/cat/abtest/spi/internal/DefaultABTestEntityManagerTest.java
+++ b/cat-core/src/test/java/com/dianping/cat/abtest/spi/internal/DefaultABTestEntityManagerTest.java
@@ -8,7 +8,6 @@ import junit.framework.Assert;
 import org.junit.Test;
 import org.unidal.lookup.ComponentTestCase;
 
-import com.dianping.cat.abtest.ABTestId;
 import com.dianping.cat.abtest.spi.ABTestEntity;
 import com.dianping.cat.abtest.spi.ABTestEntityManager;
 
@@ -18,7 +17,7 @@ public class DefaultABTestEntityManagerTest extends ComponentTestCase {
 
 	@Test
 	public void testGetEntity() throws Exception {
-		checkEntity(-1, null, null, null, null, false, true);
+		checkEntity(-1, null, null, null, null, false, false);
 		checkEntity(1001, "Mock1", "roundrobin", "This is the configuration", "2012-01-01 00:00:00", false, false);
 		checkEntity(1001, "Mock1", "roundrobin", "This is the configuration", "2013-04-10 18:00:00", true, false);
 	}
@@ -27,13 +26,18 @@ public class DefaultABTestEntityManagerTest extends ComponentTestCase {
 	      String expectedGroupStrategyConfiguration, String expectedDateStr, boolean expectedEligible,
 	      boolean expectedDisabled) throws Exception {
 		ABTestEntityManager manager = lookup(ABTestEntityManager.class);
-		ABTestId testId = new ABTestId() {
-			@Override
-			public int getValue() {
-				return id;
+		ABTestEntity entity = null;
+
+		for (ABTestEntity e : manager.getEntities().values()) {
+			if (e.getId() == id) {
+				entity = e;
+				break;
 			}
-		};
-		ABTestEntity entity = manager.getEntity(testId);
+		}
+
+		if (entity == null) {
+			return;
+		}
 
 		Assert.assertNotNull(entity);
 

--- a/cat-core/src/test/resources/com/dianping/cat/abtest/spi/internal/abtest.xml
+++ b/cat-core/src/test/resources/com/dianping/cat/abtest/spi/internal/abtest.xml
@@ -7,5 +7,4 @@
 		<domain>Cat</domain>
 		<domain>TuanGouWeb</domain>
 	</entity>
-	<entity/>
 </abtest>


### PR DESCRIPTION
思路是：以ABTestContex为核心，在filter中计算出group放到ABTestContext，而业务代码进行isGroup()时仅仅是把结果从ABTestContext中获取出
