### PR TITLE
add default value for creation_date in report_content table 

### DIFF
--- a/cat-core/src/main/resources/META-INF/dal/jdbc/report-dal.xml
+++ b/cat-core/src/main/resources/META-INF/dal/jdbc/report-dal.xml
@@ -230,6 +230,7 @@
 		</query-defs>
 	</entity>
 	<entity name="report-content" table="report_content" alias="rc" class-name="HourlyReportContent">
+	 <member name="creation-date" insert-expr="NOW()" />
      <query-defs>
      </query-defs>
     </entity>


### PR DESCRIPTION
Inserting NULLs into NOT NULL columns in mysql 5.6: refused by default
