### PR TITLE
fix the method of getting IP-address

### DIFF
--- a/cat-client/src/main/java/com/dianping/cat/configuration/NetworkInterfaceManager.java
+++ b/cat-client/src/main/java/com/dianping/cat/configuration/NetworkInterfaceManager.java
@@ -8,9 +8,14 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public enum NetworkInterfaceManager {
 	INSTANCE;
+	
+	public final String LOCALHOST = "127.0.0.1";
+	public final String ANYHOST = "0.0.0.0";
+	private final Pattern IP_PATTERN = Pattern.compile("\\d{1,3}(\\.\\d{1,3}){3,5}$");
 
 	private InetAddress m_local;
 
@@ -20,6 +25,18 @@ public enum NetworkInterfaceManager {
 
 	public InetAddress findValidateIp(List<InetAddress> addresses) {
 		InetAddress local = null;
+		
+		//getting the real IP address
+		try {
+			local = InetAddress.getLocalHost();
+			if (isValidAddress(local)) {
+				return local;
+			}
+		} catch (Throwable e) {
+			e.printStackTrace();
+			System.out.println("Failed to retriving ip address, " + e.getMessage());
+		}
+		
 		for (InetAddress address : addresses) {
 			if (address instanceof Inet4Address) {
 				if (address.isLoopbackAddress() || address.isSiteLocalAddress()) {
@@ -44,6 +61,17 @@ public enum NetworkInterfaceManager {
 			}
 		}
 		return local;
+	}
+	
+	//check the IP isValid
+	public boolean isValidAddress(InetAddress address) {
+		if (address == null || address.isLoopbackAddress())
+			return false;
+		String name = address.getHostAddress();
+		return (name != null
+				&& ! ANYHOST.equals(name)
+				&& ! LOCALHOST.equals(name)
+				&& IP_PATTERN.matcher(name).matches());
 	}
 
 	public String getLocalHostAddress() {


### PR DESCRIPTION
最近我们用CAT监控我们系统的时候，发现一个问题：我们有几台机器，部署着我们的web项目，同时部署着LVS，这时候每个机器的网卡地址包含LVS的虚拟IP，以及机器的真实IP。
但是我们打开CAT-home监控页面的时候，发现上面显示的地址是LVS的地址，而非显示真实的IP地址。现在已经修改了获取IP地址的方法。