### PR TITLE
fix Duplicate id

### DIFF
--- a/cat-client/src/main/java/com/dianping/cat/message/internal/MessageIdFactory.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/internal/MessageIdFactory.java
@@ -79,6 +79,9 @@ public class MessageIdFactory {
 			}
 
 			int index = m_index.getAndIncrement();
+            if (index % 10000 == 0){
+                saveMark();
+            }
 
 			StringBuilder sb = new StringBuilder(m_domain.length() + 32);
 
@@ -131,7 +134,7 @@ public class MessageIdFactory {
 			long lastTimestamp = m_byteBuffer.getLong();
 
 			if (lastTimestamp == m_timestamp) { // for same hour
-				m_index = new AtomicInteger(index + 10000);
+				m_index = new AtomicInteger(index);
 			} else {
 				m_index = new AtomicInteger(0);
 			}
@@ -151,7 +154,7 @@ public class MessageIdFactory {
 	public void saveMark() {
 		try {
 			m_byteBuffer.rewind();
-			m_byteBuffer.putInt(m_index.get());
+			m_byteBuffer.putInt(m_index.get()+10000);
 			m_byteBuffer.putLong(m_timestamp);
 		} catch (Exception e) {
 			// ignore it

--- a/cat-client/src/test/java/com/dianping/cat/message/internal/MessageIdFactoryTest.java
+++ b/cat-client/src/test/java/com/dianping/cat/message/internal/MessageIdFactoryTest.java
@@ -82,6 +82,11 @@ public class MessageIdFactoryTest {
 
 		String id1 = f1.getNextId();
 		String id2 = f1.getNextId();
+		for(int i=10005;i>0;i--){
+			f1.getNextId();
+		}
+
+		String id5 = f1.getNextId();
 
 		f1.close();
 
@@ -93,6 +98,8 @@ public class MessageIdFactoryTest {
 		String id4 = f2.getNextId();
 
 		// f2.close();
+
+		Assert.assertEquals(true,id5.compareTo(id3) < 0);//It is rising, indicating that duplication does not occur.
 
 		Assert.assertEquals(false, id1.equals(id2));
 		Assert.assertEquals(false, id3.equals(id4));


### PR DESCRIPTION
hello,
        I found that duplication may occur in the class MessageIdFactory, when the  id grow to more than 10000.       