### PR TITLE
bugfix/cat manual initialize flag

### DIFF
--- a/cat-client/src/main/java/com/dianping/cat/Cat.java
+++ b/cat-client/src/main/java/com/dianping/cat/Cat.java
@@ -102,9 +102,13 @@ public class Cat {
 
 	// this should be called during application initialization time
 	public static void initialize(File configFile) {
-		PlexusContainer container = ContainerLoader.getDefaultContainer();
+		synchronized (s_instance) {
+			PlexusContainer container = ContainerLoader.getDefaultContainer();
 
-		initialize(container, configFile);
+			initialize(container, configFile);
+
+			s_init = true;
+		}
 	}
 
 	public static void initialize(PlexusContainer container, File configFile) {

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
 				<groupId>org.unidal.framework</groupId>
 				<artifactId>dal-jdbc</artifactId>
 				<version>2.5.0</version>
+				<exclusions>
+					<exclusion>
+						<groupId>com.dianping.cat</groupId>
+						<artifactId>cat-client</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.unidal.framework</groupId>
@@ -59,6 +65,12 @@
 				<groupId>org.unidal.framework</groupId>
 				<artifactId>web-framework</artifactId>
 				<version>2.5.0</version>
+				<exclusions>
+					<exclusion>
+						<groupId>com.dianping.cat</groupId>
+						<artifactId>cat-client</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.unidal.framework</groupId>


### PR DESCRIPTION
手动初始化时，Cat.s_init标志位没有被设置为true，导致初始化传入的配置不生效，只有默认位置`/data/appdatas/cat/client.xml`生效。