### PR TITLE
bugfix(cat-client): Cat.initialize调用后，初始化标志不正确，导致始终加载的是默认位置的配置文件

### DIFF
--- a/cat-client/src/main/java/com/dianping/cat/Cat.java
+++ b/cat-client/src/main/java/com/dianping/cat/Cat.java
@@ -102,9 +102,13 @@ public class Cat {
 
 	// this should be called during application initialization time
 	public static void initialize(File configFile) {
-		PlexusContainer container = ContainerLoader.getDefaultContainer();
+		synchronized (s_instance) {
+			PlexusContainer container = ContainerLoader.getDefaultContainer();
 
-		initialize(container, configFile);
+			initialize(container, configFile);
+
+			s_init = true;
+		}
 	}
 
 	public static void initialize(PlexusContainer container, File configFile) {


### PR DESCRIPTION
手动初始化时，Cat.s_init标志位没有被设置为true，导致初始化传入的配置不生效，只有默认位置`/data/appdatas/cat/client.xml`生效。