### PR TITLE
specific the JDK version to suppress the IDE warnings for @Overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>2.5.1</version>
+					<configuration>
+						<source>1.6</source>
+						<target>1.6</target>
+						<encoding>utf-8</encoding>
+					</configuration>
 				</plugin>
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
InteliJ IDEA 默认JDK版本低于1.6 会对@Override Annotation报警。