### PR TITLE
修复登录页面认证时，在前端有负载均衡的时候，获取client ip错误的问题。

### DIFF
--- a/cat-client/src/main/java/com/dianping/cat/utils/HttpRequestUtils.java
+++ b/cat-client/src/main/java/com/dianping/cat/utils/HttpRequestUtils.java
@@ -1,0 +1,30 @@
+package com.dianping.cat.utils;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * 获取客户端实际ip
+ */
+public class HttpRequestUtils {
+
+    public static String getAddr(HttpServletRequest request) {
+        String ip = request.getHeader("X-Real-IP");
+
+        if (ip != null && ip.length() != 0 && !"unKnown".equalsIgnoreCase(ip)) {
+            return ip;
+        }
+        ip = request.getHeader("X-Forwarded-For");
+
+        if (ip != null && ip.length() != 0 && !"unKnown".equalsIgnoreCase(ip)) {
+            //多次反向代理后会有多个ip值，第一个ip才是真实ip
+            int index = ip.indexOf(",");
+            if (index != -1) {
+                return ip.substring(0, index);
+            } else {
+                return ip;
+            }
+        }
+
+        return request.getRemoteAddr();
+    }
+}

--- a/cat-home/src/main/java/com/dianping/cat/system/page/login/service/TokenBuilder.java
+++ b/cat-home/src/main/java/com/dianping/cat/system/page/login/service/TokenBuilder.java
@@ -4,6 +4,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.regex.Pattern;
 
 import com.dianping.cat.system.page.login.spi.ITokenBuilder;
+import com.dianping.cat.utils.HttpRequestUtils;
 
 public class TokenBuilder implements ITokenBuilder<SigninContext, Token> {
 	private static final String SP = "|";
@@ -30,7 +31,7 @@ public class TokenBuilder implements ITokenBuilder<SigninContext, Token> {
 		sb.append(value).append(SP);
 		sb.append(userNameValue).append(SP);
 		sb.append(System.currentTimeMillis()).append(SP);
-		sb.append(ctx.getRequest().getRemoteAddr()).append(SP);
+		sb.append(HttpRequestUtils.getAddr(ctx.getRequest())).append(SP);
 		sb.append(getCheckSum(sb.toString()));
 
 		return sb.toString();


### PR DESCRIPTION
修复登录页面认证时，在前端有负载均衡的时候，获取client ip错误的问题。