### PR TITLE
fix

### DIFF
--- a/cat-home/src/main/java/com/dianping/cat/system/page/login/service/TokenBuilder.java
+++ b/cat-home/src/main/java/com/dianping/cat/system/page/login/service/TokenBuilder.java
@@ -55,7 +55,8 @@ public class TokenBuilder implements ITokenBuilder<SigninContext, Token> {
 			int expectedCheckSum = getCheckSum(value.substring(0, value.lastIndexOf(SP) + 1));
 
 			if (checkSum == expectedCheckSum) {
-				if (remoteIp.equals(ctx.getRequest().getRemoteAddr())) {
+				String currAddr = HttpRequestUtils.getAddr(ctx.getRequest());
+				if (remoteIp.equals(currAddr)) {
 					if (lastLoginDate + ONE_DAY > System.currentTimeMillis()) {
 						return new Token( realName, userName);
 					}


### PR DESCRIPTION
build token和parse token中获取ip方式不一致 导致登录后，无法进入某些页面