### PR TITLE
Cat only process ERROR at most time

### DIFF
--- a/cat-client/src/main/java/com/dianping/cat/log4j/CatAppender.java
+++ b/cat-client/src/main/java/com/dianping/cat/log4j/CatAppender.java
@@ -15,12 +15,11 @@ import com.dianping.cat.message.Trace;
 public class CatAppender extends AppenderSkeleton {
 	@Override
 	protected void append(LoggingEvent event) {
-		boolean isTraceMode = Cat.getManager().isTraceMode();
 		Level level = event.getLevel();
 
 		if (level.isGreaterOrEqual(Level.ERROR)) {
 			logError(event);
-		} else if (isTraceMode) {
+		} else if (Cat.getManager().isTraceMode()) {
 			logTrace(event);
 		}
 	}


### PR DESCRIPTION
CAT在初始化时，可能会调用log4j打印日志，此时可能会有循环依赖问题，导致CAT不能正常初始化，实际上CatAppender绝大部分场景下只关心ERROR级别的日志。因此，延迟CatAppender对CAT的依赖，尽量减少发生的概率。