### PR TITLE
load app-name from System property

### DIFF
--- a/cat-client/src/main/java/com/dianping/cat/configuration/DefaultClientConfigManager.java
+++ b/cat-client/src/main/java/com/dianping/cat/configuration/DefaultClientConfigManager.java
@@ -154,6 +154,14 @@ public class DefaultClientConfigManager implements LogEnabled, ClientConfigManag
 	}
 
 	private String loadProjectName() {
+		String appName = System.getProperty("app.name");
+		if (appName == null) {
+			appName = loadProjectNameFromPropertyFile();
+		}
+		return appName;
+	}
+
+	private String loadProjectNameFromPropertyFile() {
 		String appName = null;
 		InputStream in = null;
 		try {

--- a/cat-client/src/main/java/com/dianping/cat/configuration/DefaultClientConfigManager.java
+++ b/cat-client/src/main/java/com/dianping/cat/configuration/DefaultClientConfigManager.java
@@ -155,7 +155,9 @@ public class DefaultClientConfigManager implements LogEnabled, ClientConfigManag
 
 	private String loadProjectName() {
 		String appName = System.getProperty("app.name");
-		if (appName == null) {
+		if(appName != null) {
+			m_logger.info(String.format("Find domain name %s from System.properties", appName));
+		} else {
 			appName = loadProjectNameFromPropertyFile();
 		}
 		return appName;


### PR DESCRIPTION
对于有些不适宜添加/META-INF/app.properties的项目，用户能自定义AppName。
比如ElasticSearch，同一套代码部署多个集群的场景。希望将ClusterName作为AppName，这时候希望能通过-D参数或代码自定义的方式AppName注入给CAT、