### PR TITLE
优化cat-client本地ip读取逻辑，优化对公网的ip类型的读取

### DIFF
--- a/lib/java/src/main/java/com/dianping/cat/configuration/NetworkInterfaceManager.java
+++ b/lib/java/src/main/java/com/dianping/cat/configuration/NetworkInterfaceManager.java
@@ -73,7 +73,7 @@ public enum NetworkInterfaceManager {
                         }
                     }
                 } else {
-                    if (local == null || address.isLoopbackAddress()) {
+                    if (local == null || local.isLoopbackAddress()) {
                         local = address;
                     }
                 }


### PR DESCRIPTION
真是抱歉，刚才提交的代码有问题，应该是local.isLoopbackAddress()才对