### PR TITLE
增加配置SPI:CatPropertyProvider及默认实现, 以便项目集成时实现此接口从实际的配置中获取配置项

### DIFF
--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -9,6 +9,8 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>

--- a/lib/java/src/main/java/com/dianping/cat/Cat.java
+++ b/lib/java/src/main/java/com/dianping/cat/Cat.java
@@ -59,7 +59,7 @@ public class Cat {
     public final static String UNKNOWN = "unknown";
 
     public static boolean isJstackEnabled() {
-        String enable = Properties.forString().fromEnv().fromSystem().getProperty("jstack_enable", "true");
+        String enable = CatPropertyProvider.INST.getProperty("jstack_enable", "true");
 
         return JSTACK_ENABLED && Boolean.valueOf(enable);
     }
@@ -144,7 +144,7 @@ public class Cat {
     }
 
     public static String getCatHome() {
-        return Properties.forString().fromEnv().fromSystem().getProperty("CAT_HOME", "/data/appdatas/cat/");
+        return CatPropertyProvider.INST.getProperty("CAT_HOME", "/data/appdatas/cat/");
     }
 
     public static String getCurrentMessageId() {
@@ -661,7 +661,7 @@ public class Cat {
     }
 
     private static void validate() {
-        String enable = Properties.forString().fromEnv().fromSystem().getProperty("CAT_ENABLED", "true");
+        String enable = CatPropertyProvider.INST.getProperty("CAT_ENABLED", "true");
 
         if ("false".equals(enable)) {
             CatLogger.getInstance().info("CAT is disable due to system environment CAT_ENABLED is false.");

--- a/lib/java/src/main/java/com/dianping/cat/CatPropertyProvider.java
+++ b/lib/java/src/main/java/com/dianping/cat/CatPropertyProvider.java
@@ -1,0 +1,17 @@
+package com.dianping.cat;
+
+import java.util.ServiceLoader;
+
+/**
+ * 应用属性配置SPI
+ *  此为配置的接口和扩展点，如具体应用要扩展，请实现此接口并在应用如下文件中指定实现类
+ *  META-INF\services\com.dianping.cat.CatPropertyProvider
+ * @author qxo
+ *
+ */
+public interface CatPropertyProvider {
+	
+	public static final CatPropertyProvider INST = ServiceLoader.load(CatPropertyProvider.class).iterator().next();
+
+	public String getProperty(String name, String defaultValue);
+}

--- a/lib/java/src/main/java/com/dianping/cat/configuration/ApplicationEnvironment.java
+++ b/lib/java/src/main/java/com/dianping/cat/configuration/ApplicationEnvironment.java
@@ -24,6 +24,7 @@ import com.dianping.cat.util.NetworkHelper;
 import com.dianping.cat.util.Splitters;
 import com.dianping.cat.util.StringUtils;
 import com.dianping.cat.Cat;
+import com.dianping.cat.CatPropertyProvider;
 import com.dianping.cat.configuration.client.entity.ClientConfig;
 import com.dianping.cat.configuration.client.entity.Server;
 import com.dianping.cat.configuration.client.transform.DefaultSaxParser;
@@ -79,7 +80,7 @@ public class ApplicationEnvironment {
     }
 
     private static boolean isDevMode() {
-        String devMode = com.dianping.cat.util.Properties.forString().fromEnv().fromSystem().getProperty("devMode", "false");
+        String devMode = CatPropertyProvider.INST.getProperty("devMode", "false");
 
         return "true".equals(devMode);
     }
@@ -121,8 +122,8 @@ public class ApplicationEnvironment {
         String xml = null;
 
         try {
-            File cacheFile = new File(Cat.getCatHome() + CACHE_FILE);
-            File configFile = new File(Cat.getCatHome() + CLIENT_FILE);
+            File cacheFile = new File(Cat.getCatHome(), CACHE_FILE);
+            File configFile = new File(Cat.getCatHome(), CLIENT_FILE);
 
             if (cacheFile.exists() && !isDevMode()) {
                 xml = Files.forIO().readFrom(cacheFile, "utf-8");
@@ -153,10 +154,9 @@ public class ApplicationEnvironment {
     }
 
     public static String loadRemoteClientConfig() throws Exception {
-        String host = com.dianping.cat.util.Properties.forString().fromEnv().fromSystem().getProperty("CAT_HOST", HOST);
+        String host = CatPropertyProvider.INST.getProperty("CAT_HOST", HOST);
         String path = String.format("http://%s/cat/s/launch", host);
         String hostName = NetworkInterfaceManager.INSTANCE.getLocalHostName();
-
         try {
             hostName = URLEncoder.encode(hostName, "utf-8");
         } catch (UnsupportedEncodingException ignored) {

--- a/lib/java/src/main/java/com/dianping/cat/configuration/DefaultClientConfigService.java
+++ b/lib/java/src/main/java/com/dianping/cat/configuration/DefaultClientConfigService.java
@@ -25,6 +25,7 @@ import com.dianping.cat.util.Properties;
 import com.dianping.cat.util.Splitters;
 import com.dianping.cat.util.StringUtils;
 import com.dianping.cat.Cat;
+import com.dianping.cat.CatPropertyProvider;
 import com.dianping.cat.analyzer.MetricTagAggregator;
 import com.dianping.cat.configuration.client.entity.ClientConfig;
 import com.dianping.cat.configuration.client.entity.Server;
@@ -155,7 +156,7 @@ public class DefaultClientConfigService implements ClientConfigService {
     }
 
     private boolean isDevMode() {
-        String devMode = Properties.forString().fromEnv().fromSystem().getProperty("devMode", "false");
+        String devMode = CatPropertyProvider.INST.getProperty("devMode", "false");
 
         return "true".equals(devMode);
     }

--- a/lib/java/src/main/java/com/dianping/cat/impl/CatPropertyProviderDefaultImpl.java
+++ b/lib/java/src/main/java/com/dianping/cat/impl/CatPropertyProviderDefaultImpl.java
@@ -1,0 +1,18 @@
+package com.dianping.cat.impl;
+
+import com.dianping.cat.CatPropertyProvider;
+import com.dianping.cat.util.Properties.PropertyAccessor;
+
+public class CatPropertyProviderDefaultImpl implements CatPropertyProvider {
+	
+	private PropertyAccessor<String> config;
+	
+	public CatPropertyProviderDefaultImpl() {
+		super();
+		config = com.dianping.cat.util.Properties.forString().fromEnv().fromSystem();
+	}
+
+	public String getProperty(final String name, final String defaultValue) {
+		return config.getProperty(name, defaultValue);
+	}
+}

--- a/lib/java/src/main/java/com/dianping/cat/status/datasource/c3p0/C3P0InfoCollector.java
+++ b/lib/java/src/main/java/com/dianping/cat/status/datasource/c3p0/C3P0InfoCollector.java
@@ -18,6 +18,7 @@
  */
 package com.dianping.cat.status.datasource.c3p0;
 
+import com.dianping.cat.CatPropertyProvider;
 import com.dianping.cat.status.datasource.DataSourceCollector;
 import com.dianping.cat.status.datasource.DatabaseParserHelper;
 import com.dianping.cat.util.Properties;
@@ -34,7 +35,7 @@ public class C3P0InfoCollector extends DataSourceCollector {
     private Map<String, Number> doCollect() {
         Map<String, Number> map = new LinkedHashMap<String, Number>();
         Map<String, C3P0MonitorInfo> c3P0MonitorInfoMap = getC3P0MonitorInfoMap();
-        String detail = Properties.forString().fromEnv().fromSystem().getProperty("CAT_DATASOURCE_DETAIL", "false");
+        String detail = CatPropertyProvider.INST.getProperty("CAT_DATASOURCE_DETAIL", "false");
 
         for (Map.Entry<String, C3P0MonitorInfo> entry : c3P0MonitorInfoMap.entrySet()) {
             String dataSourceName = entry.getKey();

--- a/lib/java/src/main/java/com/dianping/cat/status/datasource/druid/DruidInfoCollector.java
+++ b/lib/java/src/main/java/com/dianping/cat/status/datasource/druid/DruidInfoCollector.java
@@ -19,6 +19,7 @@
 package com.dianping.cat.status.datasource.druid;
 
 import com.dianping.cat.util.Properties;
+import com.dianping.cat.CatPropertyProvider;
 import com.dianping.cat.status.datasource.DataSourceCollector;
 import com.dianping.cat.status.datasource.DatabaseParserHelper;
 
@@ -32,7 +33,7 @@ public class DruidInfoCollector extends DataSourceCollector {
     private Map<String, Number> doCollect() {
         Map<String, DruidMonitorInfo> druidMonitorInfoMap = getDruidMonitorInfoMap();
         Map<String, Number> map = new HashMap<String, Number>();
-        String detail = Properties.forString().fromEnv().fromSystem().getProperty("CAT_DATASOURCE_DETAIL", "false");
+        String detail = CatPropertyProvider.INST.getProperty("CAT_DATASOURCE_DETAIL", "false");
 
         for (Map.Entry<String, DruidMonitorInfo> entry : druidMonitorInfoMap.entrySet()) {
             String dataSourceName = entry.getKey();

--- a/lib/java/src/main/resources/META-INF/services/com.dianping.cat.CatPropertyProvider
+++ b/lib/java/src/main/resources/META-INF/services/com.dianping.cat.CatPropertyProvider
@@ -1,0 +1,1 @@
+com.dianping.cat.impl.CatPropertyProviderDefaultImpl

--- a/lib/java/src/test/java/com/dianping/cat/CatPropertyProviderTestCase.java
+++ b/lib/java/src/test/java/com/dianping/cat/CatPropertyProviderTestCase.java
@@ -1,0 +1,17 @@
+package com.dianping.cat;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CatPropertyProviderTestCase {
+
+	@Test
+	public void test() {
+		
+		CatPropertyProvider inst = CatPropertyProvider.INST;
+		Assert.assertNotNull(inst);
+		
+		String catHost = inst.getProperty("CAT_HOST", "A");
+		Assert.assertEquals("A", catHost);
+	}
+}


### PR DESCRIPTION
实现及配置样例参考：CatPropertyProviderDefaultImpl和META-INF/services/com.dianping.cat.CatPropertyProvider
写好此代码后才能发现原来有人已写一个ClientConfigProvider
https://github.com/dianping/cat/commit/971cd6e2bd9c1245ee74b41c6195176ab453ca93
但其没覆盖到我要外部注入的配置项，故还是提交了，留给项目所有者来合并吧:)

CatPropertyProvider目前用于覆盖以下配置属性：CAT_HOME,jstack_enable,CAT_ENABLED,devMode,CAT_HOST,CAT_DATASOURCE_DETAIL