### PR TITLE
修复CatMybatisPlugin参数替换问题

### DIFF
--- a/integration/mybatis/CatMybatisPlugin.java
+++ b/integration/mybatis/CatMybatisPlugin.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 /**
@@ -40,6 +41,7 @@ import java.util.regex.Matcher;
 })
 public class CatMybatisPlugin implements Interceptor {
 
+    private static final Pattern PARAMETER_PATTERN = Pattern.compile("\\?");
     private static final String MYSQL_DEFAULT_URL = "jdbc:mysql://UUUUUKnown:3306/%s?useUnicode=true";
     private Executor target;
 
@@ -146,16 +148,22 @@ public class CatMybatisPlugin implements Interceptor {
 
             } else {
                 MetaObject metaObject = configuration.newMetaObject(parameterObject);
+                Matcher matcher = PARAMETER_PATTERN.matcher(sql);
+                StringBuffer sqlBuffer = new StringBuffer();
                 for (ParameterMapping parameterMapping : parameterMappings) {
                     String propertyName = parameterMapping.getProperty();
+                    Object obj = null;
                     if (metaObject.hasGetter(propertyName)) {
-                        Object obj = metaObject.getValue(propertyName);
-                        sql = sql.replaceFirst("\\?", Matcher.quoteReplacement(resolveParameterValue(obj)));
+                        obj = metaObject.getValue(propertyName);
                     } else if (boundSql.hasAdditionalParameter(propertyName)) {
-                        Object obj = boundSql.getAdditionalParameter(propertyName);
-                        sql = sql.replaceFirst("\\?", Matcher.quoteReplacement(resolveParameterValue(obj)));
+                        obj = boundSql.getAdditionalParameter(propertyName);
+                    }
+                    if (matcher.find()) {
+                        matcher.appendReplacement(sqlBuffer, Matcher.quoteReplacement(resolveParameterValue(obj)));
                     }
                 }
+                matcher.appendTail(sqlBuffer);
+                sql = sqlBuffer.toString();
             }
         }
         return sql;

--- a/integration/mybatis/CatMybatisPlugin.java
+++ b/integration/mybatis/CatMybatisPlugin.java
@@ -167,7 +167,7 @@ public class CatMybatisPlugin implements Interceptor {
             value = "'" + obj.toString() + "'";
         } else if (obj instanceof Date) {
             DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.CHINA);
-            value = "'" + formatter.format(new Date()) + "'";
+            value = "'" + formatter.format((Date) obj) + "'";
         } else {
             if (obj != null) {
                 value = obj.toString();


### PR DESCRIPTION
1. 修复Date类型参数没有正确替换为实际值的问题

2. 修复当参数过多的情况下，原有的sql resolve过程耗时巨大的问题。
如：批量插入sql有1M+个参数，sql长度2M+。
此时用原有方法需要遍历sql1M+次进行replaceFirst替换，耗时可达20分钟以上。
使用新的方法只需遍历sql1次，耗时在秒级以内