### PR TITLE
keep the Chinese document consistent with English version.

### DIFF
--- a/lib/java/README.zh-CN.md
+++ b/lib/java/README.zh-CN.md
@@ -30,36 +30,7 @@ app.name={appkey}
 
 > appkey 只能包含英文字母 (a-z, A-Z)、数字 (0-9)、下划线 (\_) 和中划线 (-)
 
-## SPI方式初始化
-
-cat client提供了SPI的方式扩展初始化方法，只要实现ClientConfigProvider接口
-
-```
-public class DemoClientConfigProvider implements ClientConfigProvider {
-
-	@Override
-	public ClientConfig getClientConfig() {
-		List<Server> servers = new ArrayList<Server>();
-		servers.add(new Server("192.168.199.100"));
-		servers.add(new Server("192.168.199.101"));
-		
-		String domain = "demo-app";
-
-		ClientConfig config = new ClientConfig();
-		config.setServers(servers);
-		config.setDomain(domain);
-
-		return config;
-	}
-
-}
-```
-
-新增SPI实现的配置文件META-INF/services/com.dianping.cat.configuration.ClientConfigProvider，内容如下：
-
-```
-com.demo.tracker.cat.DemoClientConfigProvider
-```
+现在java的cat client会自动懒加载，已经没有必要手动初始化客户端。
 
 ## Quickstart
 
@@ -111,7 +82,7 @@ try {
 * setTimestamp
 * complete
 
-这些 API 可以被很方便的使用，参考如下代码：
+这些 API 使用很方便，参考如下代码：
 
 ```java
 Transaction t = Cat.newTransaction("URL", "pageName");
@@ -130,9 +101,9 @@ try {
 }
 ```
 
-在使用 Transaction 提供的 API 时，你可能需要注意以下几点：
+在使用 Transaction API 时，你可能需要注意以下几点：
 
-1. 你可以调用 `addData` 多次，他们会被 `&` 连接起来。
+1. 你可以调用 `addData` 多次，添加的数据会被 `&` 连接起来。
 2. 同时指定 `duration` 和 `durationStart` 是没有意义的，尽管我们在样例中这样做了。
 3. 不要忘记完成 transaction！否则你会得到一个毁坏的消息树以及内存泄漏！
 
@@ -178,8 +149,6 @@ Cat.logError("error(X) := exception(X)", e);
 
 #### Cat.logErrorWithCategory
 
-Though `name` has been set to the classname of the given `Throwable e` by default, you can use this api to overwrite it.
-
 尽管 `name` 默认会被设置为传入的 `Throwable e` 的类名，你仍然可以使用这个 API 来复写它。
 
 ```java
@@ -216,14 +185,14 @@ Cat.logMetricForDuration("metric.key", 5);
 
 ### 日志组件集成
 
-[log4j](./../../integration/log4j/README.md)
-[log4j2](./../../integration/log4j2/README.md)
-[logback](./../../integration/logback/README.md)
+- [log4j](./../../integration/log4j/README.md)
+- [log4j2](./../../integration/log4j2/README.md)
+- [logback](./../../integration/logback/README.md)
 
 ### URL监控集成
 
-[URL monitoring integration with web.xml](./../../integration/URL/README.md)
-[URL monitoring integration with springboot](./../../integration/spring-boot/README.md)
+- [URL monitoring integration with web.xml](./../../integration/URL/README.md)
+- [URL monitoring integration with springboot](./../../integration/spring-boot/README.md)
 
 ### 更多集成方案
 


### PR DESCRIPTION
delete the cat client initialization part which may cause misunderstanding.