### PR TITLE
修复CAT编码以及单元测试的问题

### DIFF
--- a/cat-client/src/main/java/com/dianping/cat/Cat.java
+++ b/cat-client/src/main/java/com/dianping/cat/Cat.java
@@ -105,7 +105,9 @@ public class Cat {
 
 	public static String getCatHome() {
 		String catHome = CatPropertyProvider.INST.getProperty("CAT_HOME", "/data/appdatas/cat/");
-
+		if (!catHome.endsWith("/")) {
+			catHome = catHome + "/";
+		}
 		return catHome;
 	}
 

--- a/cat-client/src/main/java/com/dianping/cat/message/spi/codec/NativeMessageCodec.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/spi/codec/NativeMessageCodec.java
@@ -19,6 +19,7 @@
 package com.dianping.cat.message.spi.codec;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Stack;
 
@@ -457,7 +458,7 @@ public class NativeMessageCodec implements MessageCodec {
 			}
 
 			buf.readBytes(m_data, 0, len);
-			return new String(m_data, 0, len);
+			return new String(m_data, 0, len, StandardCharsets.UTF_8);
 		}
 
 		public long readTimestamp(ByteBuf buf) {

--- a/cat-client/src/test/java/com/dianping/cat/message/internal/CatClientTest.java
+++ b/cat-client/src/test/java/com/dianping/cat/message/internal/CatClientTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Queue;
 
+import com.dianping.cat.message.spi.MessageQueue;
 import junit.framework.Assert;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.junit.Before;
@@ -65,10 +66,9 @@ public class CatClientTest extends CatTestCase {
 	@Before
 	public void before() throws Exception {
 		TransportManager manager = Cat.lookup(TransportManager.class);
-		Initializable queue = Reflects.forField()
+		MessageQueue queue = Reflects.forField()
 								.getDeclaredFieldValue(manager.getSender().getClass(), "m_queue",	manager.getSender());
 
-		queue.initialize();
 		m_queue = Reflects.forField().getDeclaredFieldValue(queue.getClass(), "m_queue", queue);
 	}
 

--- a/cat-client/src/test/java/com/dianping/cat/message/internal/MessageProducerTest.java
+++ b/cat-client/src/test/java/com/dianping/cat/message/internal/MessageProducerTest.java
@@ -23,9 +23,9 @@ import java.io.IOException;
 import java.util.Queue;
 import java.util.Stack;
 
+import com.dianping.cat.message.spi.MessageQueue;
 import io.netty.buffer.ByteBuf;
 import junit.framework.Assert;
-import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -70,10 +70,9 @@ public class MessageProducerTest extends CatTestCase {
 	@Before
 	public void before() throws Exception {
 		TransportManager manager = Cat.lookup(TransportManager.class);
-		Initializable queue = Reflects.forField()
+		MessageQueue queue = Reflects.forField()
 								.getDeclaredFieldValue(manager.getSender().getClass(), "m_queue", manager.getSender());
 
-		queue.initialize();
 		m_queue = Reflects.forField().getDeclaredFieldValue(queue.getClass(), "m_queue", queue);
 	}
 
@@ -153,7 +152,6 @@ public class MessageProducerTest extends CatTestCase {
 		MessageCodec codec = new PlainTextMessageCodec();
 		ByteBuf buf = codec.encode(tree);
 
-		buf.readInt();
 		MessageTree tree2 = codec.decode(buf);
 
 		Assert.assertEquals(tree.toString(), tree2.toString());

--- a/cat-core/src/main/java/com/dianping/cat/message/codec/HtmlMessageCodec.java
+++ b/cat-core/src/main/java/com/dianping/cat/message/codec/HtmlMessageCodec.java
@@ -19,6 +19,7 @@
 package com.dianping.cat.message.codec;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -410,7 +411,7 @@ public class HtmlMessageCodec {
 				str = "null";
 			}
 
-			byte[] data = str.getBytes();
+			byte[] data = str.getBytes(StandardCharsets.UTF_8);
 			int count = 0;
 
 			if (attributes == null) {
@@ -418,7 +419,7 @@ public class HtmlMessageCodec {
 				count += TD1.length;
 			} else {
 				String tag = "<td " + attributes + ">";
-				byte[] bytes = tag.getBytes();
+				byte[] bytes = tag.getBytes(StandardCharsets.UTF_8);
 
 				buf.writeBytes(bytes);
 				count += bytes.length;
@@ -444,7 +445,7 @@ public class HtmlMessageCodec {
 				return TD1.length;
 			} else {
 				String tag = "<td " + attributes + ">";
-				byte[] bytes = tag.getBytes();
+				byte[] bytes = tag.getBytes(StandardCharsets.UTF_8);
 
 				buf.writeBytes(bytes);
 				return bytes.length;
@@ -462,7 +463,7 @@ public class HtmlMessageCodec {
 				return TR1.length;
 			} else {
 				String tag = "<tr class=\"" + styleClass + "\">";
-				byte[] bytes = tag.getBytes();
+				byte[] bytes = tag.getBytes(StandardCharsets.UTF_8);
 
 				buf.writeBytes(bytes);
 				return bytes.length;
@@ -484,7 +485,7 @@ public class HtmlMessageCodec {
 				str = "null";
 			}
 
-			byte[] data = str.getBytes();
+			byte[] data = str.getBytes(StandardCharsets.UTF_8);
 
 			buf.writeBytes(data);
 			return data.length;

--- a/cat-home/src/main/java/com/dianping/cat/report/page/model/Handler.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/page/model/Handler.java
@@ -23,6 +23,7 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
@@ -49,7 +50,7 @@ public class Handler extends ContainerHolder implements Initializable, PageHandl
 	private byte[] compress(String str) throws IOException {
 		ByteArrayOutputStream out = new ByteArrayOutputStream(1024 * 32);
 		GZIPOutputStream gzip = new GZIPOutputStream(out);
-		gzip.write(str.getBytes());
+		gzip.write(str.getBytes(StandardCharsets.UTF_8));
 		gzip.close();
 		return out.toByteArray();
 	}


### PR DESCRIPTION
1. 可以参考 ISSUE #1040,  服务端`NativeMessageCodec`在对Netty接受到的数据进行解码的时候, `readString` 方法使用`new String`，没有指定字符集为UTF-8，Java会使用系统默认的字符集，这个不可靠。。
2. CAT-home模块的 `com.dianping.cat.report.page.model.Handler` 的 `compress()` 方法的 getBytes()没有指定UTF-8，会导致中文出现乱码，即便上一步Netty正确解码。
3. `HtmlMessageCodec` 这个是返回给页面的编码器，很多地方`getBytes()`同样没有指定UTF-8编码，仍然会导致页面的中文乱码。
**上述问题即便在Tomcat的server.xml中配置了 `URIEncoding="utf-8"` 问题还是存在**

4. 修复单元测试， `MessageQueue` 接口不是 `Initializable`接口，不能赋值。
5. 改进 `Cat.getCatHome`, 使用JVM参数指定 CAT_HOME 容易忘记 以 "/"结束，会导致CAT启动的时候，去读取错误的位置，像： `/some/path/appdatas/catbucket`，这是可以避免的。


修复编码问题之前：
![image](https://user-images.githubusercontent.com/8142133/53628847-10942680-3c47-11e9-84eb-8bd0ad2097ae.png)

修复之后：
![image](https://user-images.githubusercontent.com/8142133/53632049-ecd4de80-3c4e-11e9-8ebe-9416ae025e39.png)

这里选择"联通"这个词是因为在Windows系统的记事本中，保存后再打开就会变成乱码。
声明：截图中的文字仅描述问题，与联通公司没有关系。 

经过与代码维护者的确认：
代码保持了type和name不支持中文的原则，不会影响type和name的编解码。

**本PR不会影响对数据存储写入时的字符编码**