### PR TITLE
CAT_HOME统一从环境变量中读取，默认值改成常量

### DIFF
--- a/cat-alarm/src/main/java/com/dianping/cat/alarm/spi/rule/RuleType.java
+++ b/cat-alarm/src/main/java/com/dianping/cat/alarm/spi/rule/RuleType.java
@@ -464,7 +464,7 @@ public enum RuleType {
 	},
 
 	UserDefine {
-		private static final String USER_DEFINED_FOLDER = "/data/appdatas/cat/user_defined_class/";
+		private final String USER_DEFINED_FOLDER = Cat.getCatHome() + "user_defined_class/";
 
 		private static final String USER_DEFINED_CLASS_NAME = "UserDefinedRule.java";
 

--- a/cat-client/src/main/java/com/dianping/cat/Cat.java
+++ b/cat-client/src/main/java/com/dianping/cat/Cat.java
@@ -104,7 +104,7 @@ public class Cat {
 	}
 
 	public static String getCatHome() {
-		String catHome = CatPropertyProvider.INST.getProperty("CAT_HOME", "/data/appdatas/cat/");
+		String catHome = CatPropertyProvider.INST.getProperty("CAT_HOME", CatConstants.CAT_HOME_DEFAULT_DIR);
 		if (!catHome.endsWith("/")) {
 			catHome = catHome + "/";
 		}

--- a/cat-client/src/main/java/com/dianping/cat/CatConstants.java
+++ b/cat-client/src/main/java/com/dianping/cat/CatConstants.java
@@ -106,4 +106,6 @@ public class CatConstants {
 
 	public static final String OTHERS = "OTHERS";
 
+	public static final String CAT_HOME_DEFAULT_DIR = "/data/appdatas/cat/";
+
 }

--- a/cat-core/src/main/java/com/dianping/cat/build/ComponentsConfigurator.java
+++ b/cat-core/src/main/java/com/dianping/cat/build/ComponentsConfigurator.java
@@ -24,8 +24,7 @@ import java.util.List;
 
 import org.unidal.dal.jdbc.configuration.AbstractJdbcResourceConfigurator;
 import org.unidal.lookup.configuration.Component;
-
-import com.dianping.cat.Cat;
+import com.dianping.cat.CatConstants;
 import com.dianping.cat.CatCoreModule;
 import com.dianping.cat.analysis.DefaultMessageAnalyzerManager;
 import com.dianping.cat.analysis.DefaultMessageHandler;
@@ -95,11 +94,9 @@ public class ComponentsConfigurator extends AbstractJdbcResourceConfigurator {
 		all.add(A(TpValueStatisticConfigManager.class));
 		all.add(A(AtomicMessageConfigManager.class));
 
-		String catHome = Cat.getCatHome();
-		if(catHome.charAt(catHome.length()-1) != '/') {
-			catHome += '/';
-		}
-		all.add(defineJdbcDataSourceConfigurationManagerComponent(catHome +"datasources.xml"));
+		all.add(defineJdbcDataSourceConfigurationManagerComponent("datasources.xml")
+				.config(E("baseDirRef").value("CAT_HOME"))
+				.config(E("defaultBaseDir").value(CatConstants.CAT_HOME_DEFAULT_DIR)));
 
 		all.addAll(new CatCoreDatabaseConfigurator().defineComponents());
 		all.addAll(new CatDatabaseConfigurator().defineComponents());

--- a/cat-core/src/main/resources/META-INF/plexus/components.xml
+++ b/cat-core/src/main/resources/META-INF/plexus/components.xml
@@ -222,7 +222,9 @@
 			<role>org.unidal.dal.jdbc.datasource.DataSourceProvider</role>
 			<implementation>org.unidal.dal.jdbc.datasource.DefaultDataSourceProvider</implementation>
 			<configuration>
-				<datasourceFile>/data/appdatas/cat/datasources.xml</datasourceFile>
+				<datasourceFile>datasources.xml</datasourceFile>
+				<baseDirRef>CAT_HOME</baseDirRef>
+				<defaultBaseDir>/data/appdatas/cat/</defaultBaseDir>
 			</configuration>
 		</component>
 		<component>

--- a/cat-home/src/main/java/com/dianping/cat/build/ComponentsConfigurator.java
+++ b/cat-home/src/main/java/com/dianping/cat/build/ComponentsConfigurator.java
@@ -26,7 +26,7 @@ import org.unidal.initialization.DefaultModuleManager;
 import org.unidal.initialization.ModuleManager;
 import org.unidal.lookup.configuration.Component;
 
-import com.dianping.cat.Cat;
+import com.dianping.cat.CatConstants;
 import com.dianping.cat.CatHomeModule;
 import com.dianping.cat.build.report.DependencyComponentConfigurator;
 import com.dianping.cat.build.report.EventComponentConfigurator;
@@ -131,11 +131,9 @@ public class ComponentsConfigurator extends AbstractJdbcResourceConfigurator {
 
 		all.addAll(new OfflineComponentConfigurator().defineComponents());
 
-		String catHome = Cat.getCatHome();
-		if( catHome.charAt(catHome.length()-1) != '/') {
-			catHome += '/';
-		}
-		all.add(defineJdbcDataSourceConfigurationManagerComponent(catHome+"datasources.xml"));
+		all.add(defineJdbcDataSourceConfigurationManagerComponent("datasources.xml")
+				.config(E("baseDirRef").value("CAT_HOME"))
+				.config(E("defaultBaseDir").value(CatConstants.CAT_HOME_DEFAULT_DIR)));
 
 		all.addAll(new CatDatabaseConfigurator().defineComponents());
 

--- a/cat-home/src/main/resources/META-INF/plexus/components.xml
+++ b/cat-home/src/main/resources/META-INF/plexus/components.xml
@@ -2510,7 +2510,9 @@
 			<role>org.unidal.dal.jdbc.datasource.DataSourceProvider</role>
 			<implementation>org.unidal.dal.jdbc.datasource.DefaultDataSourceProvider</implementation>
 			<configuration>
-				<datasourceFile>/data/appdatas/cat/datasources.xml</datasourceFile>
+				<datasourceFile>datasources.xml</datasourceFile>
+				<baseDirRef>CAT_HOME</baseDirRef>
+				<defaultBaseDir>/data/appdatas/cat/</defaultBaseDir>
 			</configuration>
 		</component>
 		<component>


### PR DESCRIPTION
根据Cat.getCatHome的含义，目的是防止写死CAT_HOME。bucket,client.xml 都能够从环境变量中读取。
但是数据源datasources.xml，由于plexus-maven-plugin在编译时调用`com.dianping.cat.build.ComponentsConfigurator.defineComponents()`，生成的数据源配置如下：
```xml
<component>
    <role>org.unidal.dal.jdbc.datasource.DataSourceProvider</role>
    <implementation>org.unidal.dal.jdbc.datasource.DefaultDataSourceProvider</implementation>
    <configuration>
        <datasourceFile>/data/appdatas/cat/datasources.xml</datasourceFile>
    </configuration>
</component>
```
这仍然是写死的路径，根据dal-jdbc的`DefaultDataSourceProvider`的源码，生成的应该是:
```xml
<component>
    <role>org.unidal.dal.jdbc.datasource.DataSourceProvider</role>
    <implementation>org.unidal.dal.jdbc.datasource.DefaultDataSourceProvider</implementation>
    <configuration>
        <datasourceFile>datasources.xml</datasourceFile>
        <baseDirRef>CAT_HOME</baseDirRef>
        <defaultBaseDir>/data/appdatas/cat/</defaultBaseDir>
    </configuration>
</component>
```
这样就避免在编译时，因为没有指定CAT_HOME，导致`defineJdbcDataSourceConfigurationManagerComponent` 接收到默认路径，
从而导致路径配置死了，最终导致在Tomcat运行时指定了CAT_HOME 已经来不及了的问题。

编译时由于datasourceFile变量是完全路径，即便在服务器上指定了ENV，CAT仍然会读取上述固定路径
报错：
```Data sources configuration(cat) is not found!```

本次改动的目的是增强CAT_HOME的一致性，避免魔法值，从而实现不再过度依赖`/data/appdatas/cat/`这个路径导致服务出现启动失败的问题。