### PR TITLE
adapter client for jdk1.6

### DIFF
--- a/lib/java/src/main/java/com/dianping/cat/message/internal/DefaultMessageProducer.java
+++ b/lib/java/src/main/java/com/dianping/cat/message/internal/DefaultMessageProducer.java
@@ -27,12 +27,13 @@ import java.io.StringWriter;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class DefaultMessageProducer implements MessageProducer {
     private MessageManager manager = DefaultMessageManager.getInstance();
     private MessageIdFactory factory = MessageIdFactory.getInstance();
-    private static ConcurrentHashMap<Long, ConcurrentHashMap<String, AtomicInteger>> stack = new ConcurrentHashMap<Long, ConcurrentHashMap<String, AtomicInteger>>();
+    private static ConcurrentMap<Long, ConcurrentHashMap<String, AtomicInteger>> stack = new ConcurrentHashMap<Long, ConcurrentHashMap<String, AtomicInteger>>();
     private static final String ERROR = "ERROR";
     private static MessageProducer INSTANCE = new DefaultMessageProducer();
 

--- a/lib/java/src/main/java/com/dianping/cat/message/internal/DefaultTransaction.java
+++ b/lib/java/src/main/java/com/dianping/cat/message/internal/DefaultTransaction.java
@@ -29,6 +29,7 @@ import com.dianping.cat.message.spi.MessageTree;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class DefaultTransaction extends AbstractMessage implements Transaction {
@@ -37,7 +38,7 @@ public class DefaultTransaction extends AbstractMessage implements Transaction {
     private List<Message> children;
     private MessageManager manager;
     private static Map<String, Integer> map = new ConcurrentHashMap<String, Integer>();
-    private static ConcurrentHashMap<Long, ConcurrentHashMap<String, AtomicInteger>> count = new ConcurrentHashMap<Long, ConcurrentHashMap<String, AtomicInteger>>();
+    private static ConcurrentMap<Long, ConcurrentHashMap<String, AtomicInteger>> count = new ConcurrentHashMap<Long, ConcurrentHashMap<String, AtomicInteger>>();
 
     public static void clearCache() {
         long time = System.currentTimeMillis() / 1000 / 60 - 3;


### PR DESCRIPTION
ConcurrentHashMap类型，在使用keySet()时，会自动调用jdk1.8才新增的KeySetView返回类型，不兼容jdk1.6