### PR TITLE
fix 消息错乱问题

### DIFF
--- a/cat-client/src/main/java/com/dianping/cat/message/internal/MessageIdFactory.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/internal/MessageIdFactory.java
@@ -167,7 +167,7 @@ public class MessageIdFactory {
 			StringBuilder sb = new StringBuilder(m_domain.length() + 32);
 
 			int processID = getProcessID();
-			if (processID > 0) {
+			if (Cat.isMultiInstanceEnable() && processID > 0) {
 				sb.append(domain).append('-').append(m_ipAddress).append(".").append(processID).append('-').append(timestamp).append('-').append(index);
 			} else {
 				sb.append(domain).append('-').append(m_ipAddress).append('-').append(timestamp).append('-').append(index);

--- a/cat-client/src/main/java/com/dianping/cat/message/internal/MessageIdFactory.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/internal/MessageIdFactory.java
@@ -166,7 +166,12 @@ public class MessageIdFactory {
 			int index = value.getAndIncrement();
 			StringBuilder sb = new StringBuilder(m_domain.length() + 32);
 
-			sb.append(domain).append('-').append(m_ipAddress).append('-').append(timestamp).append('-').append(index);
+			int processID = getProcessID();
+			if (processID > 0) {
+				sb.append(domain).append('-').append(m_ipAddress).append(".").append(processID).append('-').append(timestamp).append('-').append(index);
+			} else {
+				sb.append(domain).append('-').append(m_ipAddress).append('-').append(timestamp).append('-').append(index);
+			}
 
 			return sb.toString();
 		}


### PR DESCRIPTION
如果a和b是client，都部署在同一台机器上，同时调c(服务端）。domain、ip、hour都一样。index因为是不同的进程，就会重复。
    所以加入进程pid因子。格式：domain-ip.pid-hour-index 保证唯一