### PR TITLE
change buffer size from 4+data.length to 6

### DIFF
--- a/cat-core/src/main/java/com/dianping/cat/message/storage/MessageBlockWriter.java
+++ b/cat-core/src/main/java/com/dianping/cat/message/storage/MessageBlockWriter.java
@@ -64,7 +64,7 @@ public class MessageBlockWriter {
 		byte[] data = block.getData();
 		int blockSize = 0;
 
-		ByteBuffer buffer = ByteBuffer.allocate(4 + data.length);
+		ByteBuffer buffer = ByteBuffer.allocate(6);
 		buffer.order(ByteOrder.BIG_ENDIAN);
 
 		for (int i = 0; i < len; i++) {


### PR DESCRIPTION
每个index又一个４bytes的m_blockAddress和一个2bytes的blockSize组成。所以当把buffer写入m_indexChannel的时候，buffer的长度只需６bytes。