### PR TITLE
Remove public modifier in the interface class as they are not needed

### DIFF
--- a/cat-alarm/src/main/java/com/dianping/cat/alarm/spi/receiver/Contactor.java
+++ b/cat-alarm/src/main/java/com/dianping/cat/alarm/spi/receiver/Contactor.java
@@ -22,13 +22,13 @@ import java.util.List;
 
 public interface Contactor {
 
-	public String getId();
+	String getId();
 
-	public List<String> queryEmailContactors(String id);
+	List<String> queryEmailContactors(String id);
 
-	public List<String> queryWeiXinContactors(String id);
+	List<String> queryWeiXinContactors(String id);
 
-	public List<String> querySmsContactors(String id);
+	List<String> querySmsContactors(String id);
 
-	public List<String> queryDXContactors(String id);
+	List<String> queryDXContactors(String id);
 }

--- a/cat-alarm/src/main/java/com/dianping/cat/alarm/spi/rule/DataChecker.java
+++ b/cat-alarm/src/main/java/com/dianping/cat/alarm/spi/rule/DataChecker.java
@@ -23,10 +23,10 @@ import java.util.List;
 import com.dianping.cat.alarm.rule.entity.Condition;
 
 public interface DataChecker {
-	public List<DataCheckEntity> checkData(double[] value, double[] baseline, List<Condition> conditions);
+	List<DataCheckEntity> checkData(double[] value, double[] baseline, List<Condition> conditions);
 
-	public List<DataCheckEntity> checkData(double[] value, List<Condition> conditions);
+	List<DataCheckEntity> checkData(double[] value, List<Condition> conditions);
 
-	public List<DataCheckEntity> checkDataForApp(double[] value, List<Condition> checkedConditions);
+	List<DataCheckEntity> checkDataForApp(double[] value, List<Condition> checkedConditions);
 
 }

--- a/cat-alarm/src/main/java/com/dianping/cat/alarm/spi/sender/Sender.java
+++ b/cat-alarm/src/main/java/com/dianping/cat/alarm/spi/sender/Sender.java
@@ -20,8 +20,8 @@ package com.dianping.cat.alarm.spi.sender;
 
 public interface Sender {
 
-	public String getId();
+	String getId();
 
-	public boolean send(SendMessageEntity message);
+	boolean send(SendMessageEntity message);
 
 }

--- a/cat-alarm/src/main/java/com/dianping/cat/alarm/spi/spliter/Spliter.java
+++ b/cat-alarm/src/main/java/com/dianping/cat/alarm/spi/spliter/Spliter.java
@@ -20,8 +20,8 @@ package com.dianping.cat.alarm.spi.spliter;
 
 public interface Spliter {
 
-	public String process(String content);
+	String process(String content);
 
-	public String getID();
+	 String getID();
 
 }

--- a/cat-client/src/main/java/com/dianping/cat/CatPropertyProvider.java
+++ b/cat-client/src/main/java/com/dianping/cat/CatPropertyProvider.java
@@ -22,14 +22,14 @@ import java.util.ServiceLoader;
 
 /**
  * 应用属性配置SPI
- *  此为配置的接口和扩展点，如具体应用要扩展，请实现此接口并在应用如下文件中指定实现类
- *  META-INF\services\com.dianping.cat.CatPropertyProvider
- * @author qxo
+ * 此为配置的接口和扩展点，如具体应用要扩展，请实现此接口并在应用如下文件中指定实现类
+ * META-INF\services\com.dianping.cat.CatPropertyProvider
  *
+ * @author qxo
  */
 public interface CatPropertyProvider {
-	
-	public static final CatPropertyProvider INST = ServiceLoader.load(CatPropertyProvider.class).iterator().next();
 
-	public String getProperty(String name, String defaultValue);
+    CatPropertyProvider INST = ServiceLoader.load(CatPropertyProvider.class).iterator().next();
+
+    String getProperty(String name, String defaultValue);
 }

--- a/cat-client/src/main/java/com/dianping/cat/configuration/ClientConfigManager.java
+++ b/cat-client/src/main/java/com/dianping/cat/configuration/ClientConfigManager.java
@@ -27,30 +27,30 @@ import com.dianping.cat.message.spi.MessageTree;
 
 public interface ClientConfigManager {
 
-	public Domain getDomain();
+	Domain getDomain();
 
-	public int getMaxMessageLength();
+	int getMaxMessageLength();
 
-	public String getRouters();
+	String getRouters();
 
-	public double getSampleRatio();
+	double getSampleRatio();
 
-	public List<Server> getServers();
+	List<Server> getServers();
 
-	public int getTaggedTransactionCacheSize();
+	int getTaggedTransactionCacheSize();
 
-	public void initialize(File configFile) throws Exception;
+	void initialize(File configFile) throws Exception;
 
-	public boolean isAtomicMessage(MessageTree tree);
+	boolean isAtomicMessage(MessageTree tree);
 
-	public boolean isBlock();
+	boolean isBlock();
 
-	public boolean isCatEnabled();
+	boolean isCatEnabled();
 
-	public boolean isDumpLocked();
+	boolean isDumpLocked();
 
-	public void refreshConfig();
+	void refreshConfig();
 
-	public int getLongThresholdByDuration(String key, int duration);
+	int getLongThresholdByDuration(String key, int duration);
 
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/ForkedTransaction.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/ForkedTransaction.java
@@ -19,7 +19,7 @@
 package com.dianping.cat.message;
 
 public interface ForkedTransaction extends Transaction {
-	public void fork();
+    void fork();
 
-	public String getForkedMessageId();
+    String getForkedMessageId();
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/Message.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/Message.java
@@ -19,113 +19,113 @@
 package com.dianping.cat.message;
 
 /**
-	* <p>
-	* Message represents data collected during application runtime. It will be sent to back-end system asynchronous for
-	* further processing.
-	* </p>
-	* <p>
-	* <p>
-	* Super interface of <code>Event</code>, <code>Heartbeat</code> and <code>Transaction</code>.
-	* </p>
-	*
-	* @author Frankie Wu
-	* @see Event, Heartbeat, Transaction
-	*/
+ * <p>
+ * Message represents data collected during application runtime. It will be sent to back-end system asynchronous for
+ * further processing.
+ * </p>
+ * <p>
+ * <p>
+ * Super interface of <code>Event</code>, <code>Heartbeat</code> and <code>Transaction</code>.
+ * </p>
+ *
+ * @author Frankie Wu
+ * @see Event, Heartbeat, Transaction
+ */
 public interface Message {
-	public static final String SUCCESS = "0";
+    String SUCCESS = "0";
 
-	/**
-		* add one or multiple key-value pairs to the message.
-		*
-		* @param keyValuePairs key-value pairs like 'a=1&b=2&...'
-		*/
-	public void addData(String keyValuePairs);
+    /**
+     * add one or multiple key-value pairs to the message.
+     *
+     * @param keyValuePairs key-value pairs like 'a=1&b=2&...'
+     */
+    void addData(String keyValuePairs);
 
-	/**
-		* add one key-value pair to the message.
-		*
-		* @param key
-		* @param value
-		*/
-	public void addData(String key, Object value);
+    /**
+     * add one key-value pair to the message.
+     *
+     * @param key
+     * @param value
+     */
+    void addData(String key, Object value);
 
-	/**
-		* Complete the message construction.
-		*/
-	public void complete();
+    /**
+     * Complete the message construction.
+     */
+    void complete();
 
-	/**
-		* @return key value pairs data
-		*/
-	public Object getData();
+    /**
+     * @return key value pairs data
+     */
+    Object getData();
 
-	/**
-		* Message name.
-		*
-		* @return message name
-		*/
-	public String getName();
+    /**
+     * Message name.
+     *
+     * @return message name
+     */
+    String getName();
 
-	/**
-		* Get the message status.
-		*
-		* @return message status. "0" means success, otherwise error code.
-		*/
-	public String getStatus();
+    /**
+     * Get the message status.
+     *
+     * @return message status. "0" means success, otherwise error code.
+     */
+    String getStatus();
 
-	/**
-		* Set the message status with exception class name.
-		*
-		* @param e exception.
-		*/
-	public void setStatus(Throwable e);
+    /**
+     * Set the message status with exception class name.
+     *
+     * @param e exception.
+     */
+    void setStatus(Throwable e);
 
-	/**
-		* The time stamp the message was created.
-		*
-		* @return message creation time stamp in milliseconds
-		*/
-	public long getTimestamp();
+    /**
+     * The time stamp the message was created.
+     *
+     * @return message creation time stamp in milliseconds
+     */
+    long getTimestamp();
 
-	public void setTimestamp(long timestamp);
+    void setTimestamp(long timestamp);
 
-	/**
-		* Message type.
-		* <p>
-		* <p>
-		* Typical message types are:
-		* <ul>
-		* <li>URL: maps to one method of an action</li>
-		* <li>Service: maps to one method of service call</li>
-		* <li>Search: maps to one method of search call</li>
-		* <li>SQL: maps to one SQL statement</li>
-		* <li>Cache: maps to one cache access</li>
-		* <li>Error: maps to java.lang.Throwable (java.lang.Exception and java.lang.Error)</li>
-		* </ul>
-		* </p>
-		*
-		* @return message type
-		*/
-	public String getType();
+    /**
+     * Message type.
+     * <p>
+     * <p>
+     * Typical message types are:
+     * <ul>
+     * <li>URL: maps to one method of an action</li>
+     * <li>Service: maps to one method of service call</li>
+     * <li>Search: maps to one method of search call</li>
+     * <li>SQL: maps to one SQL statement</li>
+     * <li>Cache: maps to one cache access</li>
+     * <li>Error: maps to java.lang.Throwable (java.lang.Exception and java.lang.Error)</li>
+     * </ul>
+     * </p>
+     *
+     * @return message type
+     */
+    String getType();
 
-	/**
-		* If the complete() method was called or not.
-		*
-		* @return true means the complete() method was called, false otherwise.
-		*/
-	public boolean isCompleted();
+    /**
+     * If the complete() method was called or not.
+     *
+     * @return true means the complete() method was called, false otherwise.
+     */
+    boolean isCompleted();
 
-	/**
-		* @return
-		*/
-	public boolean isSuccess();
+    /**
+     * @return
+     */
+    boolean isSuccess();
 
-	/**
-		* Set the message status.
-		*
-		* @param status message status. "0" means success, otherwise error code.
-		*/
-	public void setStatus(String status);
+    /**
+     * Set the message status.
+     *
+     * @param status message status. "0" means success, otherwise error code.
+     */
+    void setStatus(String status);
 
-	public void setSuccessStatus();
+    void setSuccessStatus();
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/MessageProducer.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/MessageProducer.java
@@ -19,270 +19,270 @@
 package com.dianping.cat.message;
 
 /**
-	* <p>
-	* Message factory is used to create new transaction,event and/or heartbeat.
-	* </p>
-	* <p>
-	* <p>
-	* Normally, application code logs message in following ways, for example:
-	* <ul>
-	* <li>Event
-	* <p>
-	* <pre>
-	* public class MyClass {
-	*    public static MessageFactory CAT = Cat.getFactory();
-	*
-	*    public void bizMethod() {
-	*       Event event = CAT.newEvent("Review", "New");
-	*
-	*       event.addData("id", 12345);
-	*       event.addData("user", "john");
-	*       ...
-	*       event.setStatus("0");
-	*       event.complete();
-	*    }
-	*    ...
-	* }
-	* </pre>
-	* <p>
-	* </li>
-	* <li>Heartbeat
-	* <p>
-	* <pre>
-	* public class MyClass {
-	*    public static MessageFactory CAT = Cat.getFactory();
-	*
-	*    public void bizMethod() {
-	*       Heartbeat event = CAT.newHeartbeat("System", "Status");
-	*
-	*       event.addData("ip", "192.168.10.111");
-	*       event.addData("host", "host-1");
-	*       event.addData("load", "2.1");
-	*       event.addData("cpu", "0.12,0.10");
-	*       event.addData("memory.total", "2G");
-	*       event.addData("memory.free", "456M");
-	*       event.setStatus("0");
-	*       event.complete();
-	*    }
-	*    ...
-	* }
-	* </pre>
-	* <p>
-	* </li>
-	* <li>Transaction
-	* <p>
-	* <pre>
-	* public class MyClass {
-	*    public static MessageFactory CAT = Cat.getFactory();
-	*
-	*    public void bizMethod() {
-	*       Transaction t = CAT.newTransaction("URL", "MyPage");
-	*
-	*       try {
-	*          // do your business here
-	*          t.addData("k1", "v1");
-	*          t.addData("k2", "v2");
-	*          t.addData("k3", "v3");
-	*          Thread.sleep(30);
-	*
-	*          t.setStatus("0");
-	*       } catch (Exception e) {
-	*          t.setStatus(e);
-	*       } finally {
-	*          t.complete();
-	*       }
-	*    }
-	*    ...
-	* }
-	* </pre>
-	* <p>
-	* </li>
-	* </ul>
-	* <p>
-	* or logs event or heartbeat in one shot, for example:
-	* <ul>
-	* <li>Event
-	* <p>
-	* <pre>
-	* public class MyClass {
-	*    public static MessageFactory CAT = Cat.getFactory();
-	*
-	*    public void bizMethod() {
-	*       CAT.logEvent("Review", "New", "0", "id=12345&user=john");
-	*    }
-	*    ...
-	* }
-	* </pre>
-	* <p>
-	* </li>
-	* <li>Heartbeat
-	* <p>
-	* <pre>
-	* public class MyClass {
-	*    public static MessageFactory CAT = Cat.getFactory();
-	*
-	*    public void bizMethod() {
-	*       CAT.logHeartbeat("System", "Status", "0", "ip=192.168.10.111&host=host-1&load=2.1&cpu=0.12,0.10&memory.total=2G&memory.free=456M");
-	*    }
-	*    ...
-	* }
-	* </pre>
-	* <p>
-	* </li>
-	* </ul>
-	* </p>
-	*
-	* @author Frankie Wu
-	*/
+ * <p>
+ * Message factory is used to create new transaction,event and/or heartbeat.
+ * </p>
+ * <p>
+ * <p>
+ * Normally, application code logs message in following ways, for example:
+ * <ul>
+ * <li>Event
+ * <p>
+ * <pre>
+ * public class MyClass {
+ *    public static MessageFactory CAT = Cat.getFactory();
+ *
+ *    public void bizMethod() {
+ *       Event event = CAT.newEvent("Review", "New");
+ *
+ *       event.addData("id", 12345);
+ *       event.addData("user", "john");
+ *       ...
+ *       event.setStatus("0");
+ *       event.complete();
+ *    }
+ *    ...
+ * }
+ * </pre>
+ * <p>
+ * </li>
+ * <li>Heartbeat
+ * <p>
+ * <pre>
+ * public class MyClass {
+ *    public static MessageFactory CAT = Cat.getFactory();
+ *
+ *    public void bizMethod() {
+ *       Heartbeat event = CAT.newHeartbeat("System", "Status");
+ *
+ *       event.addData("ip", "192.168.10.111");
+ *       event.addData("host", "host-1");
+ *       event.addData("load", "2.1");
+ *       event.addData("cpu", "0.12,0.10");
+ *       event.addData("memory.total", "2G");
+ *       event.addData("memory.free", "456M");
+ *       event.setStatus("0");
+ *       event.complete();
+ *    }
+ *    ...
+ * }
+ * </pre>
+ * <p>
+ * </li>
+ * <li>Transaction
+ * <p>
+ * <pre>
+ * public class MyClass {
+ *    public static MessageFactory CAT = Cat.getFactory();
+ *
+ *    public void bizMethod() {
+ *       Transaction t = CAT.newTransaction("URL", "MyPage");
+ *
+ *       try {
+ *          // do your business here
+ *          t.addData("k1", "v1");
+ *          t.addData("k2", "v2");
+ *          t.addData("k3", "v3");
+ *          Thread.sleep(30);
+ *
+ *          t.setStatus("0");
+ *       } catch (Exception e) {
+ *          t.setStatus(e);
+ *       } finally {
+ *          t.complete();
+ *       }
+ *    }
+ *    ...
+ * }
+ * </pre>
+ * <p>
+ * </li>
+ * </ul>
+ * <p>
+ * or logs event or heartbeat in one shot, for example:
+ * <ul>
+ * <li>Event
+ * <p>
+ * <pre>
+ * public class MyClass {
+ *    public static MessageFactory CAT = Cat.getFactory();
+ *
+ *    public void bizMethod() {
+ *       CAT.logEvent("Review", "New", "0", "id=12345&user=john");
+ *    }
+ *    ...
+ * }
+ * </pre>
+ * <p>
+ * </li>
+ * <li>Heartbeat
+ * <p>
+ * <pre>
+ * public class MyClass {
+ *    public static MessageFactory CAT = Cat.getFactory();
+ *
+ *    public void bizMethod() {
+ *       CAT.logHeartbeat("System", "Status", "0", "ip=192.168.10.111&host=host-1&load=2.1&cpu=0.12,0.10&memory.total=2G&memory.free=456M");
+ *    }
+ *    ...
+ * }
+ * </pre>
+ * <p>
+ * </li>
+ * </ul>
+ * </p>
+ *
+ * @author Frankie Wu
+ */
 public interface MessageProducer {
-	/**
-		* Create rpc server message id.
-		* <p>
-		* domain is the rpc server
-		*
-		* @return new message id
-		*/
-	public String createRpcServerId(String domain);
+    /**
+     * Create rpc server message id.
+     * <p>
+     * domain is the rpc server
+     *
+     * @return new message id
+     */
+    String createRpcServerId(String domain);
 
-	/**
-		* Create a new message id.
-		*
-		* @return new message id
-		*/
-	public String createMessageId();
+    /**
+     * Create a new message id.
+     *
+     * @return new message id
+     */
+    String createMessageId();
 
-	/**
-		* Check if the CAT client is enabled for current domain.
-		*
-		* @return true if CAT client is enabled, false means CAT client is disabled.
-		*/
-	public boolean isEnabled();
+    /**
+     * Check if the CAT client is enabled for current domain.
+     *
+     * @return true if CAT client is enabled, false means CAT client is disabled.
+     */
+    boolean isEnabled();
 
-	/**
-		* Log an error.
-		*
-		* @param cause root cause exception
-		*/
-	public void logError(String message, Throwable cause);
+    /**
+     * Log an error.
+     *
+     * @param cause root cause exception
+     */
+    void logError(String message, Throwable cause);
 
-	/**
-		* Log an error.
-		*
-		* @param cause root cause exception
-		*/
-	public void logError(Throwable cause);
+    /**
+     * Log an error.
+     *
+     * @param cause root cause exception
+     */
+    void logError(Throwable cause);
 
-	/**
-		* Log an event in one shot with SUCCESS status.
-		*
-		* @param type event type
-		* @param name event name
-		*/
-	public void logEvent(String type, String name);
+    /**
+     * Log an event in one shot with SUCCESS status.
+     *
+     * @param type event type
+     * @param name event name
+     */
+    void logEvent(String type, String name);
 
-	/**
-		* Log an event in one shot.
-		*
-		* @param type           event type
-		* @param name           event name
-		* @param status         "0" means success, otherwise means error code
-		* @param nameValuePairs name value pairs in the format of "a=1&b=2&..."
-		*/
-	public void logEvent(String type, String name, String status, String nameValuePairs);
+    /**
+     * Log an event in one shot.
+     *
+     * @param type           event type
+     * @param name           event name
+     * @param status         "0" means success, otherwise means error code
+     * @param nameValuePairs name value pairs in the format of "a=1&b=2&..."
+     */
+    void logEvent(String type, String name, String status, String nameValuePairs);
 
-	/**
-		* Log a heartbeat in one shot.
-		*
-		* @param type           heartbeat type
-		* @param name           heartbeat name
-		* @param status         "0" means success, otherwise means error code
-		* @param nameValuePairs name value pairs in the format of "a=1&b=2&..."
-		*/
-	public void logHeartbeat(String type, String name, String status, String nameValuePairs);
+    /**
+     * Log a heartbeat in one shot.
+     *
+     * @param type           heartbeat type
+     * @param name           heartbeat name
+     * @param status         "0" means success, otherwise means error code
+     * @param nameValuePairs name value pairs in the format of "a=1&b=2&..."
+     */
+    void logHeartbeat(String type, String name, String status, String nameValuePairs);
 
-	/**
-		* Log a metric in one shot.
-		*
-		* @param name           metric name
-		* @param status         "0" means success, otherwise means error code
-		* @param nameValuePairs name value pairs in the format of "a=1&b=2&..."
-		*/
-	public void logMetric(String name, String status, String nameValuePairs);
+    /**
+     * Log a metric in one shot.
+     *
+     * @param name           metric name
+     * @param status         "0" means success, otherwise means error code
+     * @param nameValuePairs name value pairs in the format of "a=1&b=2&..."
+     */
+    void logMetric(String name, String status, String nameValuePairs);
 
-	/**
-		* Log an trace in one shot with SUCCESS status.
-		*
-		* @param type trace type
-		* @param name trace name
-		*/
-	public void logTrace(String type, String name);
+    /**
+     * Log an trace in one shot with SUCCESS status.
+     *
+     * @param type trace type
+     * @param name trace name
+     */
+    void logTrace(String type, String name);
 
-	/**
-		* Log an trace in one shot.
-		*
-		* @param type           trace type
-		* @param name           trace name
-		* @param status         "0" means success, otherwise means error code
-		* @param nameValuePairs name value pairs in the format of "a=1&b=2&..."
-		*/
-	public void logTrace(String type, String name, String status, String nameValuePairs);
+    /**
+     * Log an trace in one shot.
+     *
+     * @param type           trace type
+     * @param name           trace name
+     * @param status         "0" means success, otherwise means error code
+     * @param nameValuePairs name value pairs in the format of "a=1&b=2&..."
+     */
+    void logTrace(String type, String name, String status, String nameValuePairs);
 
-	/**
-		* Create a new event with given type and name.
-		*
-		* @param type event type
-		* @param name event name
-		*/
-	public Event newEvent(String type, String name);
+    /**
+     * Create a new event with given type and name.
+     *
+     * @param type event type
+     * @param name event name
+     */
+    Event newEvent(String type, String name);
 
-	/**
-		* Create a forked transaction for child thread.
-		*
-		* @param type transaction type
-		* @param name transaction name
-		* @return forked transaction
-		*/
-	public ForkedTransaction newForkedTransaction(String type, String name);
+    /**
+     * Create a forked transaction for child thread.
+     *
+     * @param type transaction type
+     * @param name transaction name
+     * @return forked transaction
+     */
+    ForkedTransaction newForkedTransaction(String type, String name);
 
-	/**
-		* Create a new heartbeat with given type and name.
-		*
-		* @param type heartbeat type
-		* @param name heartbeat name
-		*/
-	public Heartbeat newHeartbeat(String type, String name);
+    /**
+     * Create a new heartbeat with given type and name.
+     *
+     * @param type heartbeat type
+     * @param name heartbeat name
+     */
+    Heartbeat newHeartbeat(String type, String name);
 
-	/**
-		* Create a new metric with given type and name.
-		*
-		* @param type metric type
-		* @param name metric name
-		*/
-	public Metric newMetric(String type, String name);
+    /**
+     * Create a new metric with given type and name.
+     *
+     * @param type metric type
+     * @param name metric name
+     */
+    Metric newMetric(String type, String name);
 
-	/**
-		* Create a tagged transaction for another process or thread.
-		*
-		* @param type transaction type
-		* @param name transaction name
-		* @param tag  tag applied to the transaction
-		* @return tagged transaction
-		*/
-	public TaggedTransaction newTaggedTransaction(String type, String name, String tag);
+    /**
+     * Create a tagged transaction for another process or thread.
+     *
+     * @param type transaction type
+     * @param name transaction name
+     * @param tag  tag applied to the transaction
+     * @return tagged transaction
+     */
+    TaggedTransaction newTaggedTransaction(String type, String name, String tag);
 
-	/**
-		* Create a new trace with given type and name.
-		*
-		* @param type trace type
-		* @param name trace name
-		*/
-	public Trace newTrace(String type, String name);
+    /**
+     * Create a new trace with given type and name.
+     *
+     * @param type trace type
+     * @param name trace name
+     */
+    Trace newTrace(String type, String name);
 
-	/**
-		* Create a new transaction with given type and name.
-		*
-		* @param type transaction type
-		* @param name transaction name
-		*/
-	public Transaction newTransaction(String type, String name);
+    /**
+     * Create a new transaction with given type and name.
+     *
+     * @param type transaction type
+     * @param name transaction name
+     */
+    Transaction newTransaction(String type, String name);
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/TaggedTransaction.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/TaggedTransaction.java
@@ -19,13 +19,13 @@
 package com.dianping.cat.message;
 
 public interface TaggedTransaction extends Transaction {
-	public void bind(String tag, String childMessageId, String title);
+    void bind(String tag, String childMessageId, String title);
 
-	public String getParentMessageId();
+    String getParentMessageId();
 
-	public String getRootMessageId();
+    String getRootMessageId();
 
-	public String getTag();
+    String getTag();
 
-	public void start();
+    void start();
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/Transaction.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/Transaction.java
@@ -21,85 +21,85 @@ package com.dianping.cat.message;
 import java.util.List;
 
 /**
-	* <p>
-	* <code>Transaction</code> is any interesting unit of work that takes time to complete and may fail.
-	* </p>
-	* <p>
-	* <p>
-	* Basically, all data access across the boundary needs to be logged as a <code>Transaction</code> since it may fail and
-	* time consuming. For example, URL request, disk IO, JDBC query, search query, HTTP request, 3rd party API call etc.
-	* </p>
-	* <p>
-	* <p>
-	* Sometime if A needs call B which is owned by another team, although A and B are deployed together without any
-	* physical boundary. To make the ownership clear, there could be some <code>Transaction</code> logged when A calls B.
-	* </p>
-	* <p>
-	* <p>
-	* Most of <code>Transaction</code> should be logged in the infrastructure level or framework level, which is
-	* transparent to the application.
-	* </p>
-	* <p>
-	* <p>
-	* All CAT message will be constructed as a message tree and send to back-end for further analysis, and for monitoring.
-	* Only <code>Transaction</code> can be a tree node, all other message will be the tree leaf.　The transaction without
-	* other messages nested is an atomic transaction.
-	* </p>
-	*
-	* @author Frankie Wu
-	*/
+ * <p>
+ * <code>Transaction</code> is any interesting unit of work that takes time to complete and may fail.
+ * </p>
+ * <p>
+ * <p>
+ * Basically, all data access across the boundary needs to be logged as a <code>Transaction</code> since it may fail and
+ * time consuming. For example, URL request, disk IO, JDBC query, search query, HTTP request, 3rd party API call etc.
+ * </p>
+ * <p>
+ * <p>
+ * Sometime if A needs call B which is owned by another team, although A and B are deployed together without any
+ * physical boundary. To make the ownership clear, there could be some <code>Transaction</code> logged when A calls B.
+ * </p>
+ * <p>
+ * <p>
+ * Most of <code>Transaction</code> should be logged in the infrastructure level or framework level, which is
+ * transparent to the application.
+ * </p>
+ * <p>
+ * <p>
+ * All CAT message will be constructed as a message tree and send to back-end for further analysis, and for monitoring.
+ * Only <code>Transaction</code> can be a tree node, all other message will be the tree leaf.　The transaction without
+ * other messages nested is an atomic transaction.
+ * </p>
+ *
+ * @author Frankie Wu
+ */
 public interface Transaction extends Message {
-	/**
-		* Add one nested child message to current transaction.
-		*
-		* @param message to be added
-		*/
-	public Transaction addChild(Message message);
+    /**
+     * Add one nested child message to current transaction.
+     *
+     * @param message to be added
+     */
+    Transaction addChild(Message message);
 
-	/**
-		* Get all children message within current transaction.
-		* <p>
-		* <p>
-		* Typically, a <code>Transaction</code> can nest other <code>Transaction</code>s, <code>Event</code>s and
-		* <code>Heartbeat</code> s, while an <code>Event</code> or <code>Heartbeat</code> can't nest other messages.
-		* </p>
-		*
-		* @return all children messages, empty if there is no nested children.
-		*/
-	public List<Message> getChildren();
+    /**
+     * Get all children message within current transaction.
+     * <p>
+     * <p>
+     * Typically, a <code>Transaction</code> can nest other <code>Transaction</code>s, <code>Event</code>s and
+     * <code>Heartbeat</code> s, while an <code>Event</code> or <code>Heartbeat</code> can't nest other messages.
+     * </p>
+     *
+     * @return all children messages, empty if there is no nested children.
+     */
+    List<Message> getChildren();
 
-	/**
-		* How long the transaction took from construction to complete. Time unit is microsecond.
-		*
-		* @return duration time in microsecond
-		*/
-	public long getDurationInMicros();
+    /**
+     * How long the transaction took from construction to complete. Time unit is microsecond.
+     *
+     * @return duration time in microsecond
+     */
+    long getDurationInMicros();
 
-	/**
-		* How long the transaction took from construction to complete. Time unit is millisecond.
-		*
-		* @return duration time in millisecond
-		*/
-	public long getDurationInMillis();
+    /**
+     * How long the transaction took from construction to complete. Time unit is millisecond.
+     *
+     * @return duration time in millisecond
+     */
+    long getDurationInMillis();
 
-	/**
-		* set duration in millisecond.
-		*
-		* @return duration time in millisecond
-		*/
-	public void setDurationInMillis(long durationInMills);
+    /**
+     * set duration in millisecond.
+     *
+     * @return duration time in millisecond
+     */
+    void setDurationInMillis(long durationInMills);
 
-	/**
-		* Has children or not. An atomic transaction does not have any children message.
-		*
-		* @return true if child exists, else false.
-		*/
-	public boolean hasChildren();
+    /**
+     * Has children or not. An atomic transaction does not have any children message.
+     *
+     * @return true if child exists, else false.
+     */
+    boolean hasChildren();
 
-	/**
-		* Check if the transaction is stand-alone or belongs to another one.
-		*
-		* @return true if it's an root transaction.
-		*/
-	public boolean isStandalone();
+    /**
+     * Check if the transaction is stand-alone or belongs to another one.
+     *
+     * @return true if it's an root transaction.
+     */
+    boolean isStandalone();
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/io/MessageSender.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/io/MessageSender.java
@@ -24,9 +24,9 @@ import java.util.List;
 import com.dianping.cat.message.spi.MessageTree;
 
 public interface MessageSender {
-	public void initialize(List<InetSocketAddress> addresses);
+	void initialize(List<InetSocketAddress> addresses);
 
-	public void send(MessageTree tree);
+	void send(MessageTree tree);
 
-	public void shutdown();
+	void shutdown();
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/io/TransportManager.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/io/TransportManager.java
@@ -19,5 +19,5 @@
 package com.dianping.cat.message.io;
 
 public interface TransportManager {
-	public MessageSender getSender();
+	MessageSender getSender();
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/spi/MessageCodec.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/spi/MessageCodec.java
@@ -21,22 +21,22 @@ package com.dianping.cat.message.spi;
 import io.netty.buffer.ByteBuf;
 
 public interface MessageCodec {
-	/**
-		* decode buf to message tree
-		* first 4 bytes is the length of message tree
-		*
-		* @param buf
-		* @return message
-		*/
-	public MessageTree decode(ByteBuf buf);
+    /**
+     * decode buf to message tree
+     * first 4 bytes is the length of message tree
+     *
+     * @param buf
+     * @return message
+     */
+    MessageTree decode(ByteBuf buf);
 
-	/**
-		* encode message tree to buf
-		*
-		* @param tree
-		* @return buf  first 4 bytes is the length of message tree
-		*/
-	public ByteBuf encode(MessageTree tree);
+    /**
+     * encode message tree to buf
+     *
+     * @param tree
+     * @return buf  first 4 bytes is the length of message tree
+     */
+    ByteBuf encode(MessageTree tree);
 
-	public void reset();
+    void reset();
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/spi/MessageManager.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/spi/MessageManager.java
@@ -23,101 +23,101 @@ import com.dianping.cat.message.Message;
 import com.dianping.cat.message.Transaction;
 
 /**
-	* Message manager to help build CAT message.
-	* <p>
-	* <p>
-	* Notes: This method is reserved for internal usage only. Application developer should never call this method directly.
-	*/
+ * Message manager to help build CAT message.
+ * <p>
+ * <p>
+ * Notes: This method is reserved for internal usage only. Application developer should never call this method directly.
+ */
 public interface MessageManager {
-	public void add(Message message);
+    void add(Message message);
 
-	/**
-		* Be triggered when a transaction ends, whatever it's the root transaction or nested transaction. However, if it's
-		* the root transaction then it will be flushed to back-end CAT server asynchronously.
-		* <p>
-		*
-		* @param transaction
-		*/
-	public void end(Transaction transaction);
+    /**
+     * Be triggered when a transaction ends, whatever it's the root transaction or nested transaction. However, if it's
+     * the root transaction then it will be flushed to back-end CAT server asynchronously.
+     * <p>
+     *
+     * @param transaction
+     */
+    void end(Transaction transaction);
 
-	/**
-		* Get peek transaction for current thread.
-		*
-		* @return peek transaction for current thread, null if no transaction there.
-		*/
-	public Transaction getPeekTransaction();
+    /**
+     * Get peek transaction for current thread.
+     *
+     * @return peek transaction for current thread, null if no transaction there.
+     */
+    Transaction getPeekTransaction();
 
-	/**
-		* Get thread local message information.
-		*
-		* @return message tree, null means current thread is not setup correctly.
-		*/
-	public MessageTree getThreadLocalMessageTree();
+    /**
+     * Get thread local message information.
+     *
+     * @return message tree, null means current thread is not setup correctly.
+     */
+    MessageTree getThreadLocalMessageTree();
 
-	/**
-		* Check if the thread context is setup or not.
-		*
-		* @return true if the thread context is setup, false otherwise
-		*/
-	public boolean hasContext();
+    /**
+     * Check if the thread context is setup or not.
+     *
+     * @return true if the thread context is setup, false otherwise
+     */
+    boolean hasContext();
 
-	/**
-		* Check if current context logging is enabled or disabled.
-		*
-		* @return true if current context is enabled
-		*/
-	public boolean isMessageEnabled();
+    /**
+     * Check if current context logging is enabled or disabled.
+     *
+     * @return true if current context is enabled
+     */
+    boolean isMessageEnabled();
 
-	/**
-		* Check if CAT logging is enabled or disabled.
-		*
-		* @return true if CAT is enabled
-		*/
-	public boolean isCatEnabled();
+    /**
+     * Check if CAT logging is enabled or disabled.
+     *
+     * @return true if CAT is enabled
+     */
+    boolean isCatEnabled();
 
-	/**
-		* Check if CAT trace mode is enabled or disabled.
-		*
-		* @return true if CAT is trace mode
-		*/
-	public boolean isTraceMode();
+    /**
+     * Check if CAT trace mode is enabled or disabled.
+     *
+     * @return true if CAT is trace mode
+     */
+    boolean isTraceMode();
 
-	/**
-		* Set CAT trace mode.
-		*/
-	public void setTraceMode(boolean traceMode);
+    /**
+     * Set CAT trace mode.
+     */
+    void setTraceMode(boolean traceMode);
 
-	/**
-		* Do cleanup for current thread environment in order to release resources in thread local objects.
-		*/
-	public void reset();
+    /**
+     * Do cleanup for current thread environment in order to release resources in thread local objects.
+     */
+    void reset();
 
-	/**
-		* Do setup for current thread environment in order to prepare thread local objects.
-		*/
-	public void setup();
+    /**
+     * Do setup for current thread environment in order to prepare thread local objects.
+     */
+    void setup();
 
-	/**
-		* Be triggered when a new transaction starts, whatever it's the root transaction or nested transaction.
-		*
-		* @param transaction
-		* @param forked
-		*/
-	public void start(Transaction transaction, boolean forked);
+    /**
+     * Be triggered when a new transaction starts, whatever it's the root transaction or nested transaction.
+     *
+     * @param transaction
+     * @param forked
+     */
+    void start(Transaction transaction, boolean forked);
 
-	/**
-		* Binds the current message tree to the transaction tagged with <code>tag</code>.
-		*
-		* @param tag   tag name of the tagged transaction
-		* @param title title shown in the logview
-		*/
-	public void bind(String tag, String title);
+    /**
+     * Binds the current message tree to the transaction tagged with <code>tag</code>.
+     *
+     * @param tag   tag name of the tagged transaction
+     * @param title title shown in the logview
+     */
+    void bind(String tag, String title);
 
-	/**
-		* get domain
-		*/
-	public String getDomain();
+    /**
+     * get domain
+     */
+    String getDomain();
 
-	public ClientConfigManager getConfigManager();
+    ClientConfigManager getConfigManager();
 
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/spi/MessageQueue.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/spi/MessageQueue.java
@@ -19,12 +19,12 @@
 package com.dianping.cat.message.spi;
 
 public interface MessageQueue {
-	public boolean offer(MessageTree tree);
+	boolean offer(MessageTree tree);
 
-	public MessageTree peek();
+	MessageTree peek();
 
-	public MessageTree poll();
+	MessageTree poll();
 
 	// the current size of the queue
-	public int size();
+	int size();
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/spi/MessageStatistics.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/spi/MessageStatistics.java
@@ -19,14 +19,14 @@
 package com.dianping.cat.message.spi;
 
 public interface MessageStatistics {
-	public long getBytes();
+    long getBytes();
 
-	public long getOverflowed();
+    long getOverflowed();
 
-	public long getProduced();
+    long getProduced();
 
-	public void onBytes(int size);
+    void onBytes(int size);
 
-	public void onOverflowed(MessageTree tree);
+    void onOverflowed(MessageTree tree);
 
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/spi/MessageTree.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/spi/MessageTree.java
@@ -30,86 +30,86 @@ import com.dianping.cat.message.Transaction;
 import com.dianping.cat.message.internal.MessageId;
 
 public interface MessageTree extends Cloneable {
-	public boolean canDiscard();
+    boolean canDiscard();
 
-	public MessageTree copy();
+    MessageTree copy();
 
-	public List<Event> findOrCreateEvents();
+    List<Event> findOrCreateEvents();
 
-	public List<Heartbeat> findOrCreateHeartbeats();
+    List<Heartbeat> findOrCreateHeartbeats();
 
-	public List<Metric> findOrCreateMetrics();
+    List<Metric> findOrCreateMetrics();
 
-	public List<Transaction> findOrCreateTransactions();
+    List<Transaction> findOrCreateTransactions();
 
-	public ByteBuf getBuffer();
+    ByteBuf getBuffer();
 
-	public String getDomain();
+    String getDomain();
 
-	public void setDomain(String domain);
+    void setDomain(String domain);
 
-	public List<Event> getEvents();
+    List<Event> getEvents();
 
-	public MessageId getFormatMessageId();
+    MessageId getFormatMessageId();
 
-	public void setFormatMessageId(MessageId messageId);
+    void setFormatMessageId(MessageId messageId);
 
-	public List<Heartbeat> getHeartbeats();
+    List<Heartbeat> getHeartbeats();
 
-	public String getHostName();
+    String getHostName();
 
-	public void setHostName(String hostName);
+    void setHostName(String hostName);
 
-	public String getIpAddress();
+    String getIpAddress();
 
-	public void setIpAddress(String ipAddress);
+    void setIpAddress(String ipAddress);
 
-	public String getSessionToken();
+    String getSessionToken();
 
-	public void setSessionToken(String session);
+    void setSessionToken(String session);
 
-	public Message getMessage();
+    Message getMessage();
 
-	public void setMessage(Message message);
+    void setMessage(Message message);
 
-	public String getMessageId();
+    String getMessageId();
 
-	public void setMessageId(String messageId);
+    void setMessageId(String messageId);
 
-	public List<Metric> getMetrics();
+    List<Metric> getMetrics();
 
-	public String getParentMessageId();
+    String getParentMessageId();
 
-	public void setParentMessageId(String parentMessageId);
+    void setParentMessageId(String parentMessageId);
 
-	public String getRootMessageId();
+    String getRootMessageId();
 
-	public void setRootMessageId(String rootMessageId);
+    void setRootMessageId(String rootMessageId);
 
-	public String getThreadGroupName();
+    String getThreadGroupName();
 
-	public void setThreadGroupName(String name);
+    void setThreadGroupName(String name);
 
-	public String getThreadId();
+    String getThreadId();
 
-	public void setThreadId(String threadId);
+    void setThreadId(String threadId);
 
-	public String getThreadName();
+    String getThreadName();
 
-	public void setThreadName(String id);
+    void setThreadName(String id);
 
-	public List<Transaction> getTransactions();
+    List<Transaction> getTransactions();
 
-	public boolean isProcessLoss();
+    boolean isProcessLoss();
 
-	public void setProcessLoss(boolean loss);
+    void setProcessLoss(boolean loss);
 
-	public void setDiscard(boolean discard);
+    void setDiscard(boolean discard);
 
-	public boolean isHitSample();
+    boolean isHitSample();
 
-	public void setHitSample(boolean hitSample);
+    void setHitSample(boolean hitSample);
 
-	public void setDiscardPrivate(boolean discard);
+    void setDiscardPrivate(boolean discard);
 
 }

--- a/cat-client/src/main/java/com/dianping/cat/message/spi/codec/BufferWriter.java
+++ b/cat-client/src/main/java/com/dianping/cat/message/spi/codec/BufferWriter.java
@@ -21,5 +21,5 @@ package com.dianping.cat.message.spi.codec;
 import io.netty.buffer.ByteBuf;
 
 public interface BufferWriter {
-	public int writeTo(ByteBuf buf, byte[] data);
+	int writeTo(ByteBuf buf, byte[] data);
 }

--- a/cat-client/src/main/java/com/dianping/cat/status/StatusExtension.java
+++ b/cat-client/src/main/java/com/dianping/cat/status/StatusExtension.java
@@ -22,9 +22,9 @@ import java.util.Map;
 
 public interface StatusExtension {
 
-	public String getId();
+    String getId();
 
-	public String getDescription();
+    String getDescription();
 
-	public Map<String, String> getProperties();
+    Map<String, String> getProperties();
 }

--- a/cat-consumer/src/main/java/com/dianping/cat/consumer/storage/builder/StorageBuilder.java
+++ b/cat-consumer/src/main/java/com/dianping/cat/consumer/storage/builder/StorageBuilder.java
@@ -24,12 +24,12 @@ import com.dianping.cat.message.Transaction;
 
 public interface StorageBuilder {
 
-	public StorageItem build(Transaction t);
+    StorageItem build(Transaction t);
 
-	public List<String> getDefaultMethods();
+    List<String> getDefaultMethods();
 
-	public String getType();
+    String getType();
 
-	public boolean isEligable(Transaction t);
+    boolean isEligable(Transaction t);
 
 }

--- a/cat-core/src/main/java/com/dianping/cat/analysis/MessageAnalyzer.java
+++ b/cat-core/src/main/java/com/dianping/cat/analysis/MessageAnalyzer.java
@@ -24,21 +24,21 @@ import com.dianping.cat.report.ReportManager;
 
 public interface MessageAnalyzer {
 
-	public boolean isEligable(MessageTree tree);
+    boolean isEligable(MessageTree tree);
 
-	public void analyze(MessageQueue queue);
+    void analyze(MessageQueue queue);
 
-	public void destroy();
+    void destroy();
 
-	public void doCheckpoint(boolean atEnd);
+    void doCheckpoint(boolean atEnd);
 
-	public long getStartTime();
+    long getStartTime();
 
-	public void initialize(long startTime, long duration, long extraTime);
+    void initialize(long startTime, long duration, long extraTime);
 
-	public int getAnanlyzerCount(String name);
+    int getAnanlyzerCount(String name);
 
-	public void setIndex(int index);
+    void setIndex(int index);
 
-	public ReportManager<?> getReportManager();
+    ReportManager<?> getReportManager();
 }

--- a/cat-core/src/main/java/com/dianping/cat/analysis/MessageAnalyzerManager.java
+++ b/cat-core/src/main/java/com/dianping/cat/analysis/MessageAnalyzerManager.java
@@ -21,7 +21,7 @@ package com.dianping.cat.analysis;
 import java.util.List;
 
 public interface MessageAnalyzerManager {
-	public List<String> getAnalyzerNames();
+    List<String> getAnalyzerNames();
 
-	public List<MessageAnalyzer> getAnalyzer(String name, long startTime);
+    List<MessageAnalyzer> getAnalyzer(String name, long startTime);
 }

--- a/cat-core/src/main/java/com/dianping/cat/analysis/MessageConsumer.java
+++ b/cat-core/src/main/java/com/dianping/cat/analysis/MessageConsumer.java
@@ -23,11 +23,11 @@ import java.util.List;
 import com.dianping.cat.message.spi.MessageTree;
 
 public interface MessageConsumer {
-	public void consume(MessageTree tree);
+	void consume(MessageTree tree);
 
-	public void doCheckpoint();
+	void doCheckpoint();
 
-	public List<MessageAnalyzer> getCurrentAnalyzer(String name);
+	List<MessageAnalyzer> getCurrentAnalyzer(String name);
 
-	public List<MessageAnalyzer> getLastAnalyzer(String name);
+	List<MessageAnalyzer> getLastAnalyzer(String name);
 }

--- a/cat-core/src/main/java/com/dianping/cat/analysis/MessageHandler.java
+++ b/cat-core/src/main/java/com/dianping/cat/analysis/MessageHandler.java
@@ -21,5 +21,5 @@ package com.dianping.cat.analysis;
 import com.dianping.cat.message.spi.MessageTree;
 
 public interface MessageHandler {
-	public void handle(MessageTree message);
+	void handle(MessageTree message);
 }

--- a/cat-core/src/main/java/com/dianping/cat/config/content/ContentFetcher.java
+++ b/cat-core/src/main/java/com/dianping/cat/config/content/ContentFetcher.java
@@ -20,6 +20,6 @@ package com.dianping.cat.config.content;
 
 public interface ContentFetcher {
 
-	public String getConfigContent(String configName);
+	String getConfigContent(String configName);
 
 }

--- a/cat-core/src/main/java/com/dianping/cat/message/PathBuilder.java
+++ b/cat-core/src/main/java/com/dianping/cat/message/PathBuilder.java
@@ -21,7 +21,7 @@ package com.dianping.cat.message;
 import java.util.Date;
 
 public interface PathBuilder {
-	public String getLogviewPath(Date timestamp, String name);
+    String getLogviewPath(Date timestamp, String name);
 
-	public String getReportPath(String name, Date timestamp, int index);
+    String getReportPath(String name, Date timestamp, int index);
 }

--- a/cat-core/src/main/java/com/dianping/cat/message/storage/MessageBucket.java
+++ b/cat-core/src/main/java/com/dianping/cat/message/storage/MessageBucket.java
@@ -24,14 +24,14 @@ import java.util.Date;
 import com.dianping.cat.message.spi.MessageTree;
 
 public interface MessageBucket {
-	public void close() throws IOException;
+    void close() throws IOException;
 
-	public MessageTree findById(String messageId) throws IOException;
+    MessageTree findById(String messageId) throws IOException;
 
-	public long getLastAccessTime();
+    long getLastAccessTime();
 
-	public void initialize(String dataFile) throws IOException;
+    void initialize(String dataFile) throws IOException;
 
-	public void initialize(String dataFile, Date date) throws IOException;
+    void initialize(String dataFile, Date date) throws IOException;
 
 }

--- a/cat-core/src/main/java/com/dianping/cat/message/storage/MessageBucketManager.java
+++ b/cat-core/src/main/java/com/dianping/cat/message/storage/MessageBucketManager.java
@@ -22,9 +22,9 @@ import com.dianping.cat.message.internal.MessageId;
 import com.dianping.cat.message.spi.MessageTree;
 
 public interface MessageBucketManager {
-	public void archive(long startTime);
+    void archive(long startTime);
 
-	public MessageTree loadMessage(String messageId);
+    MessageTree loadMessage(String messageId);
 
-	public void storeMessage(MessageTree tree, MessageId id);
+    void storeMessage(MessageTree tree, MessageId id);
 }

--- a/cat-core/src/main/java/com/dianping/cat/report/ReportBucket.java
+++ b/cat-core/src/main/java/com/dianping/cat/report/ReportBucket.java
@@ -23,54 +23,54 @@ import java.util.Collection;
 import java.util.Date;
 
 public interface ReportBucket {
-	/**
-		* Close bucket and release component instance
-		*
-		* @throws IOException
-		*/
-	public void close() throws IOException;
+    /**
+     * Close bucket and release component instance
+     *
+     * @throws IOException
+     */
+    void close() throws IOException;
 
-	/**
-		* Find data by given id in the bucket. return null if not found.
-		*
-		* @param id
-		* @return data for given id, null if not found
-		* @throws IOException
-		*/
-	public String findById(String id) throws IOException;
+    /**
+     * Find data by given id in the bucket. return null if not found.
+     *
+     * @param id
+     * @return data for given id, null if not found
+     * @throws IOException
+     */
+    String findById(String id) throws IOException;
 
-	/**
-		* Flush the buffered data in the bucket if have.
-		*
-		* @throws IOException
-		*/
-	public void flush() throws IOException;
+    /**
+     * Flush the buffered data in the bucket if have.
+     *
+     * @throws IOException
+     */
+    void flush() throws IOException;
 
-	/**
-		* Return all ids in the bucket.
-		*
-		* @return
-		*/
-	public Collection<String> getIds();
+    /**
+     * Return all ids in the bucket.
+     *
+     * @return
+     */
+    Collection<String> getIds();
 
-	/**
-		* Initialize the bucket after its creation.
-		*
-		* @param name
-		* @param timestamp
-		* @param index
-		* @throws IOException
-		*/
-	public void initialize(String name, Date timestamp, int index) throws IOException;
+    /**
+     * Initialize the bucket after its creation.
+     *
+     * @param name
+     * @param timestamp
+     * @param index
+     * @throws IOException
+     */
+    void initialize(String name, Date timestamp, int index) throws IOException;
 
-	/**
-		* store the data by id into the bucket.
-		*
-		* @param id
-		* @param data
-		* @return true means the data was stored in the bucket, otherwise false.
-		* @throws IOException
-		*/
-	public boolean storeById(String id, String data) throws IOException;
+    /**
+     * store the data by id into the bucket.
+     *
+     * @param id
+     * @param data
+     * @return true means the data was stored in the bucket, otherwise false.
+     * @throws IOException
+     */
+    boolean storeById(String id, String data) throws IOException;
 
 }

--- a/cat-core/src/main/java/com/dianping/cat/report/ReportBucketManager.java
+++ b/cat-core/src/main/java/com/dianping/cat/report/ReportBucketManager.java
@@ -22,9 +22,9 @@ import java.io.IOException;
 
 public interface ReportBucketManager {
 
-	public void closeBucket(ReportBucket bucket);
+    void closeBucket(ReportBucket bucket);
 
-	public void clearOldReports();
+    void clearOldReports();
 
-	public ReportBucket getReportBucket(long timestamp, String name, int index) throws IOException;
+    ReportBucket getReportBucket(long timestamp, String name, int index) throws IOException;
 }

--- a/cat-core/src/main/java/com/dianping/cat/report/ReportDelegate.java
+++ b/cat-core/src/main/java/com/dianping/cat/report/ReportDelegate.java
@@ -21,24 +21,24 @@ package com.dianping.cat.report;
 import java.util.Map;
 
 public interface ReportDelegate<T> {
-	public void afterLoad(Map<String, T> reports);
+    void afterLoad(Map<String, T> reports);
 
-	public void beforeSave(Map<String, T> reports);
+    void beforeSave(Map<String, T> reports);
 
-	public byte[] buildBinary(T report);
+    byte[] buildBinary(T report);
 
-	public T parseBinary(byte[] bytes);
+    T parseBinary(byte[] bytes);
 
-	public String buildXml(T report);
+    String buildXml(T report);
 
-	public String getDomain(T report);
+    String getDomain(T report);
 
-	public T makeReport(String domain, long startTime, long duration);
+    T makeReport(String domain, long startTime, long duration);
 
-	public T mergeReport(T old, T other);
+    T mergeReport(T old, T other);
 
-	public T parseXml(String xml) throws Exception;
+    T parseXml(String xml) throws Exception;
 
-	public boolean createHourlyTask(T report);
+    boolean createHourlyTask(T report);
 
 }

--- a/cat-core/src/main/java/com/dianping/cat/report/ReportManager.java
+++ b/cat-core/src/main/java/com/dianping/cat/report/ReportManager.java
@@ -25,20 +25,20 @@ import com.dianping.cat.report.DefaultReportManager.StoragePolicy;
 
 public interface ReportManager<T> {
 
-	public void destory();
+    void destory();
 
-	public void initialize();
+    void initialize();
 
-	public Set<String> getDomains(long startTime);
+    Set<String> getDomains(long startTime);
 
-	public T getHourlyReport(long startTime, String domain, boolean createIfNotExist);
+    T getHourlyReport(long startTime, String domain, boolean createIfNotExist);
 
-	public Map<String, T> getHourlyReports(long startTime);
+    Map<String, T> getHourlyReports(long startTime);
 
-	public Map<String, T> loadHourlyReports(long startTime, StoragePolicy policy, int index);
+    Map<String, T> loadHourlyReports(long startTime, StoragePolicy policy, int index);
 
-	public Map<String, T> loadLocalReports(long startTime, int index);
+    Map<String, T> loadLocalReports(long startTime, int index);
 
-	public void storeHourlyReports(long startTime, StoragePolicy policy, int index);
+    void storeHourlyReports(long startTime, StoragePolicy policy, int index);
 
 }

--- a/cat-core/src/main/java/com/dianping/cat/report/server/ServersUpdater.java
+++ b/cat-core/src/main/java/com/dianping/cat/report/server/ServersUpdater.java
@@ -24,6 +24,6 @@ import java.util.Set;
 
 public interface ServersUpdater {
 
-	public Map<String, Set<String>> buildServers(Date hour);
+	Map<String, Set<String>> buildServers(Date hour);
 
 }

--- a/cat-core/src/main/java/com/dianping/cat/report/service/ModelService.java
+++ b/cat-core/src/main/java/com/dianping/cat/report/service/ModelService.java
@@ -20,9 +20,9 @@ package com.dianping.cat.report.service;
 
 public interface ModelService<M> {
 
-	public String getName();
+	String getName();
 
-	public ModelResponse<M> invoke(ModelRequest request);
+	ModelResponse<M> invoke(ModelRequest request);
 
-	public boolean isEligable(ModelRequest request);
+	boolean isEligable(ModelRequest request);
 }

--- a/cat-core/src/main/java/com/dianping/cat/report/service/ReportService.java
+++ b/cat-core/src/main/java/com/dianping/cat/report/service/ReportService.java
@@ -27,24 +27,24 @@ import com.dianping.cat.core.dal.MonthlyReport;
 import com.dianping.cat.core.dal.WeeklyReport;
 
 public interface ReportService<T> {
-	public boolean insertDailyReport(DailyReport report, byte[] content);
+    boolean insertDailyReport(DailyReport report, byte[] content);
 
-	public boolean insertHourlyReport(HourlyReport report, byte[] content);
+    boolean insertHourlyReport(HourlyReport report, byte[] content);
 
-	public boolean insertMonthlyReport(MonthlyReport report, byte[] content);
+    boolean insertMonthlyReport(MonthlyReport report, byte[] content);
 
-	public boolean insertWeeklyReport(WeeklyReport report, byte[] content);
+    boolean insertWeeklyReport(WeeklyReport report, byte[] content);
 
-	public Set<String> queryAllDomainNames(Date start, Date end, String name);
+    Set<String> queryAllDomainNames(Date start, Date end, String name);
 
-	public T queryDailyReport(String domain, Date start, Date end);
+    T queryDailyReport(String domain, Date start, Date end);
 
-	public T queryHourlyReport(String domain, Date start, Date end);
+    T queryHourlyReport(String domain, Date start, Date end);
 
-	public T queryMonthlyReport(String domain, Date start);
+    T queryMonthlyReport(String domain, Date start);
 
-	public T queryWeeklyReport(String domain, Date start);
+    T queryWeeklyReport(String domain, Date start);
 
-	public T queryReport(String domain, Date start, Date end);
+    T queryReport(String domain, Date start, Date end);
 
 }

--- a/cat-core/src/main/java/com/dianping/cat/server/DataSourceService.java
+++ b/cat-core/src/main/java/com/dianping/cat/server/DataSourceService.java
@@ -22,6 +22,6 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 
 public interface DataSourceService<T> extends Initializable {
 
-	public T getConnection(String category);
+    T getConnection(String category);
 
 }

--- a/cat-core/src/main/java/com/dianping/cat/server/MetricService.java
+++ b/cat-core/src/main/java/com/dianping/cat/server/MetricService.java
@@ -23,24 +23,24 @@ import java.util.Map;
 
 public interface MetricService {
 
-	public boolean insert(List<MetricEntity> entities);
+    boolean insert(List<MetricEntity> entities);
 
-	public Map<Long, Double> query(QueryParameter parameter);
+    Map<Long, Double> query(QueryParameter parameter);
 
-	public List<ServerGroupByEntity> queryByFields(QueryParameter parameter);
+    List<ServerGroupByEntity> queryByFields(QueryParameter parameter);
 
-	public List<String> queryEndPoints(String category);
+    List<String> queryEndPoints(String category);
 
-	public List<String> queryEndPoints(String category, String tag, List<String> keywords);
+    List<String> queryEndPoints(String category, String tag, List<String> keywords);
 
-	public List<String> queryEndPointsByTag(String category, List<String> tags);
+    List<String> queryEndPointsByTag(String category, List<String> tags);
 
-	public List<String> queryMeasurements(String category);
+    List<String> queryMeasurements(String category);
 
-	public List<String> queryMeasurements(String category, List<String> endPoints);
+    List<String> queryMeasurements(String category, List<String> endPoints);
 
-	public List<String> queryMeasurements(String category, String measurement, List<String> endPoints);
+    List<String> queryMeasurements(String category, String measurement, List<String> endPoints);
 
-	public List<String> queryTagValues(String category, String measurement, String tag);
+    List<String> queryTagValues(String category, String measurement, String tag);
 
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/Block.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/Block.java
@@ -26,24 +26,24 @@ import io.netty.buffer.ByteBuf;
 import com.dianping.cat.message.internal.MessageId;
 
 public interface Block {
-	public void clear();
+    void clear();
 
-	public ByteBuf find(MessageId id);
+    ByteBuf find(MessageId id);
 
-	public void finish();
+    void finish();
 
-	public ByteBuf getData() throws IOException;
+    ByteBuf getData() throws IOException;
 
-	public String getDomain();
+    String getDomain();
 
-	public int getHour();
+    int getHour();
 
-	public Map<MessageId, Integer> getOffsets();
+    Map<MessageId, Integer> getOffsets();
 
-	public boolean isFull();
+    boolean isFull();
 
-	public void pack(MessageId id, ByteBuf buf) throws IOException;
+    void pack(MessageId id, ByteBuf buf) throws IOException;
 
-	public ByteBuf unpack(MessageId id) throws IOException;
+    ByteBuf unpack(MessageId id) throws IOException;
 
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/BlockDumper.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/BlockDumper.java
@@ -21,9 +21,9 @@ package org.unidal.cat.message.storage;
 import java.io.IOException;
 
 public interface BlockDumper {
-	public void awaitTermination() throws InterruptedException;
+    void awaitTermination() throws InterruptedException;
 
-	public void dump(Block block) throws IOException;
+    void dump(Block block) throws IOException;
 
-	public void initialize(int hour);
+    void initialize(int hour);
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/BlockDumperManager.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/BlockDumperManager.java
@@ -19,7 +19,7 @@
 package org.unidal.cat.message.storage;
 
 public interface BlockDumperManager {
-	public void close(int hour);
+	void close(int hour);
 
-	public BlockDumper findOrCreate(int hour);
+	BlockDumper findOrCreate(int hour);
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/BlockWriter.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/BlockWriter.java
@@ -23,6 +23,6 @@ import java.util.concurrent.BlockingQueue;
 import org.unidal.helper.Threads.Task;
 
 public interface BlockWriter extends Task {
-	public void initialize(int hour, int index, BlockingQueue<Block> queue);
+	void initialize(int hour, int index, BlockingQueue<Block> queue);
 
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/Bucket.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/Bucket.java
@@ -26,23 +26,23 @@ import io.netty.buffer.ByteBuf;
 import com.dianping.cat.message.internal.MessageId;
 
 public interface Bucket {
-	public static final long SEGMENT_SIZE = 32 * 1024L;
+    long SEGMENT_SIZE = 32 * 1024L;
 
-	public static final int BYTE_PER_MESSAGE = 8;
+    int BYTE_PER_MESSAGE = 8;
 
-	public static final int BYTE_PER_ENTRY = 8;
+    int BYTE_PER_ENTRY = 8;
 
-	public static final int MESSAGE_PER_SEGMENT = (int) (SEGMENT_SIZE / BYTE_PER_MESSAGE);
+    int MESSAGE_PER_SEGMENT = (int) (SEGMENT_SIZE / BYTE_PER_MESSAGE);
 
-	public static final int ENTRY_PER_SEGMENT = (int) (SEGMENT_SIZE / BYTE_PER_ENTRY);
+    int ENTRY_PER_SEGMENT = (int) (SEGMENT_SIZE / BYTE_PER_ENTRY);
 
-	public void close();
+    void close();
 
-	public void flush();
+    void flush();
 
-	public ByteBuf get(MessageId id) throws IOException;
+    ByteBuf get(MessageId id) throws IOException;
 
-	public boolean initialize(String domain, String ip, int hour, boolean writeMode) throws IOException;
+    boolean initialize(String domain, String ip, int hour, boolean writeMode) throws IOException;
 
-	public void puts(ByteBuf buf, Map<MessageId, Integer> mappings) throws IOException;
+    void puts(ByteBuf buf, Map<MessageId, Integer> mappings) throws IOException;
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/BucketManager.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/BucketManager.java
@@ -21,8 +21,8 @@ package org.unidal.cat.message.storage;
 import java.io.IOException;
 
 public interface BucketManager {
-	public void closeBuckets(int hour);
+	void closeBuckets(int hour);
 
-	public Bucket getBucket(String domain, String ip, int hour, boolean createIfNotExists) throws IOException;
+	Bucket getBucket(String domain, String ip, int hour, boolean createIfNotExists) throws IOException;
 
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/Index.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/Index.java
@@ -25,13 +25,13 @@ import com.dianping.cat.message.internal.MessageId;
 
 public interface Index {
 
-	public void close();
+    void close();
 
-	public MessageId find(MessageId from) throws IOException;
+    MessageId find(MessageId from) throws IOException;
 
-	public void initialize(String domain, String ip, int hour) throws IOException;
+    void initialize(String domain, String ip, int hour) throws IOException;
 
-	public void map(MessageId from, MessageId to) throws IOException;
+    void map(MessageId from, MessageId to) throws IOException;
 
-	public void maps(Map<MessageId, MessageId> maps) throws IOException;
+    void maps(Map<MessageId, MessageId> maps) throws IOException;
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/IndexManager.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/IndexManager.java
@@ -21,7 +21,7 @@ package org.unidal.cat.message.storage;
 import java.io.IOException;
 
 public interface IndexManager {
-	public void close(int hour);
+    void close(int hour);
 
-	public Index getIndex(String domain, String ip, int hour, boolean createIfNotExists) throws IOException;
+    Index getIndex(String domain, String ip, int hour, boolean createIfNotExists) throws IOException;
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/MessageDumper.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/MessageDumper.java
@@ -21,9 +21,9 @@ package org.unidal.cat.message.storage;
 import com.dianping.cat.message.spi.MessageTree;
 
 public interface MessageDumper {
-	public void awaitTermination(int hour) throws InterruptedException;
+    void awaitTermination(int hour) throws InterruptedException;
 
-	public void initialize(int hour);
+    void initialize(int hour);
 
-	public void process(MessageTree tree);
+    void process(MessageTree tree);
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/MessageDumperManager.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/MessageDumperManager.java
@@ -19,9 +19,9 @@
 package org.unidal.cat.message.storage;
 
 public interface MessageDumperManager {
-	public abstract void close(int hour);
+	void close(int hour);
 
-	public abstract MessageDumper find(int hour);
+	MessageDumper find(int hour);
 
-	public abstract MessageDumper findOrCreate(int hour);
+	MessageDumper findOrCreate(int hour);
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/MessageFinder.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/MessageFinder.java
@@ -23,5 +23,5 @@ import io.netty.buffer.ByteBuf;
 import com.dianping.cat.message.internal.MessageId;
 
 public interface MessageFinder {
-	public ByteBuf find(MessageId id);
+	ByteBuf find(MessageId id);
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/MessageFinderManager.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/MessageFinderManager.java
@@ -23,9 +23,9 @@ import io.netty.buffer.ByteBuf;
 import com.dianping.cat.message.internal.MessageId;
 
 public interface MessageFinderManager {
-	public void close(int hour);
+	void close(int hour);
 
-	public ByteBuf find(MessageId id);
+	ByteBuf find(MessageId id);
 
-	public void register(int hour, MessageFinder finder);
+	void register(int hour, MessageFinder finder);
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/MessageProcessor.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/MessageProcessor.java
@@ -25,5 +25,5 @@ import org.unidal.helper.Threads.Task;
 import com.dianping.cat.message.spi.MessageTree;
 
 public interface MessageProcessor extends Task {
-	public void initialize(int hour, int index, BlockingQueue<MessageTree> queue);
+	void initialize(int hour, int index, BlockingQueue<MessageTree> queue);
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/PathBuilder.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/PathBuilder.java
@@ -21,6 +21,6 @@ package org.unidal.cat.message.storage;
 import java.util.Date;
 
 public interface PathBuilder {
-	public String getPath(String domain, Date startTime, String consumerId, FileType type);
+	String getPath(String domain, Date startTime, String consumerId, FileType type);
 
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/StorageConfiguration.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/StorageConfiguration.java
@@ -21,11 +21,11 @@ package org.unidal.cat.message.storage;
 import java.io.File;
 
 public interface StorageConfiguration {
-	public String getBaseDataDir();
+    String getBaseDataDir();
 
-	public void setBaseDataDir(String baseDataDir);
+    void setBaseDataDir(String baseDataDir);
 
-	public boolean isLocalMode();
+    boolean isLocalMode();
 
-	public void setBaseDataDir(File baseDataDir);
+    void setBaseDataDir(File baseDataDir);
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/TokenMapping.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/TokenMapping.java
@@ -21,13 +21,13 @@ package org.unidal.cat.message.storage;
 import java.io.IOException;
 
 public interface TokenMapping {
-	public void close();
+    void close();
 
-	public String find(int index) throws IOException;
+    String find(int index) throws IOException;
 
-	public long getLastAccessTime();
+    long getLastAccessTime();
 
-	public int map(String token) throws IOException;
+    int map(String token) throws IOException;
 
-	public void open(int hour, String ip) throws IOException;
+    void open(int hour, String ip) throws IOException;
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/TokenMappingManager.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/TokenMappingManager.java
@@ -21,7 +21,7 @@ package org.unidal.cat.message.storage;
 import java.io.IOException;
 
 public interface TokenMappingManager {
-	public void close(int hour);
+    void close(int hour);
 
-	public TokenMapping getTokenMapping(int hour, String ip) throws IOException;
+    TokenMapping getTokenMapping(int hour, String ip) throws IOException;
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/hdfs/MessageConsumerFinder.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/hdfs/MessageConsumerFinder.java
@@ -22,6 +22,6 @@ import java.util.Set;
 
 public interface MessageConsumerFinder {
 
-	public Set<String> findConsumerIps(String domain, int hour);
+	Set<String> findConsumerIps(String domain, int hour);
 
 }

--- a/cat-hadoop/src/main/java/org/unidal/cat/message/storage/internals/ByteBufCache.java
+++ b/cat-hadoop/src/main/java/org/unidal/cat/message/storage/internals/ByteBufCache.java
@@ -22,8 +22,8 @@ import java.nio.ByteBuffer;
 
 public interface ByteBufCache {
 
-	public ByteBuffer get();
+	ByteBuffer get();
 
-	public void put(ByteBuffer buf);
+	void put(ByteBuffer buf);
 
 }

--- a/cat-home/src/main/java/com/dianping/cat/report/graph/metric/DataExtractor.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/graph/metric/DataExtractor.java
@@ -22,11 +22,11 @@ import java.util.Map;
 
 public interface DataExtractor {
 
-	public int calculateInterval(int length);
+    int calculateInterval(int length);
 
-	public double[] extract(double[] values);
+    double[] extract(double[] values);
 
-	public Map<String, double[]> extract(final Map<String, double[]> values);
+    Map<String, double[]> extract(final Map<String, double[]> values);
 
-	public int getStep();
+    int getStep();
 }

--- a/cat-home/src/main/java/com/dianping/cat/report/graph/svg/GraphBuilder.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/graph/svg/GraphBuilder.java
@@ -19,7 +19,7 @@
 package com.dianping.cat.report.graph.svg;
 
 public interface GraphBuilder {
-	public String build(GraphPayload payload);
+    String build(GraphPayload payload);
 
-	public void setGraphType(int GraphType);
+    void setGraphType(int GraphType);
 }

--- a/cat-home/src/main/java/com/dianping/cat/report/graph/svg/GraphPayload.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/graph/svg/GraphPayload.java
@@ -19,47 +19,47 @@
 package com.dianping.cat.report.graph.svg;
 
 public interface GraphPayload {
-	public String getAxisXLabel(int index);
+    String getAxisXLabel(int index);
 
-	public String getAxisXTitle();
+    String getAxisXTitle();
 
-	public String getAxisYTitle();
+    String getAxisYTitle();
 
-	public int getColumns();
+    int getColumns();
 
-	public String getDescription();
+    String getDescription();
 
-	public int getDisplayHeight();
+    int getDisplayHeight();
 
-	public int getDisplayWidth();
+    int getDisplayWidth();
 
-	public int getHeight();
+    int getHeight();
 
-	public String getIdPrefix();
+    String getIdPrefix();
 
-	public int getMarginBottom();
+    int getMarginBottom();
 
-	public int getMarginLeft();
+    int getMarginLeft();
 
-	public int getMarginRight();
+    int getMarginRight();
 
-	public int getMarginTop();
+    int getMarginTop();
 
-	public int getOffsetX();
+    int getOffsetX();
 
-	public int getOffsetY();
+    int getOffsetY();
 
-	public int getRows();
+    int getRows();
 
-	public String getTitle();
+    String getTitle();
 
-	public double[] getValues();
+    double[] getValues();
 
-	public int getWidth();
+    int getWidth();
 
-	public boolean isAxisXLabelRotated();
+    boolean isAxisXLabelRotated();
 
-	public boolean isAxisXLabelSkipped();
+    boolean isAxisXLabelSkipped();
 
-	public boolean isStandalone();
+    boolean isStandalone();
 }

--- a/cat-home/src/main/java/com/dianping/cat/report/graph/svg/ValueTranslater.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/graph/svg/ValueTranslater.java
@@ -19,7 +19,7 @@
 package com.dianping.cat.report.graph.svg;
 
 public interface ValueTranslater {
-	public double getMaxValue(double[] values);
+    double getMaxValue(double[] values);
 
-	public int[] translate(int height, double maxValue, double[] values);
+    int[] translate(int height, double maxValue, double[] values);
 }

--- a/cat-home/src/main/java/com/dianping/cat/report/task/TaskBuilder.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/task/TaskBuilder.java
@@ -22,12 +22,12 @@ import java.util.Date;
 
 public interface TaskBuilder {
 
-	public boolean buildDailyTask(String name, String domain, Date period);
+    boolean buildDailyTask(String name, String domain, Date period);
 
-	public boolean buildHourlyTask(String name, String domain, Date period);
+    boolean buildHourlyTask(String name, String domain, Date period);
 
-	public boolean buildMonthlyTask(String name, String domain, Date period);
+    boolean buildMonthlyTask(String name, String domain, Date period);
 
-	public boolean buildWeeklyTask(String name, String domain, Date period);
+    boolean buildWeeklyTask(String name, String domain, Date period);
 
 }


### PR DESCRIPTION
What the PR entail is essentially removing the public modifier from all the interface classes because in Java methods declared in the interface have to be public. 

Just one minor changes which might or might not be needed. Let me know if this is OK to be merged, or if there is any side effect by doing so 
