### PR TITLE
【Transaction告警、Event告警、心跳告警、异常告警】- 告警开关

### DIFF
--- a/cat-alarm/src/main/resources/META-INF/dal/model/monitor-rules-codegen.xml
+++ b/cat-alarm/src/main/resources/META-INF/dal/model/monitor-rules-codegen.xml
@@ -5,6 +5,7 @@
   </entity>
   <entity name="rule">
     <attribute name="id" value-type="String" />
+    <attribute name="available" value-type="boolean"/>
     <entity-ref name="metric-item" />
     <entity-ref name="config" />
   </entity>

--- a/cat-alarm/src/main/resources/META-INF/dal/model/monitor-rules-model.xml
+++ b/cat-alarm/src/main/resources/META-INF/dal/model/monitor-rules-model.xml
@@ -5,6 +5,7 @@
 	</entity>
 	<entity name="rule" dynamic-attributes="true">
 		<attribute name="id" value-type="String" key="true" />
+		<attribute name="available" value-type="boolean"/>
 		<entity-ref name="metric-item" type="list" names="metric-items" />
 		<entity-ref name="config" type="list" names="configs" />
 	</entity>

--- a/cat-home/src/main/java/com/dianping/cat/report/alert/event/EventAlert.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/alert/event/EventAlert.java
@@ -269,6 +269,10 @@ public class EventAlert implements Task, LogEnabled {
 				Map<String, Rule> rules = monitorRules.getRules();
 
 				for (Entry<String, Rule> entry : rules.entrySet()) {
+					//Event告警开关
+					if (!entry.getValue().getAvailable()) {
+						continue;
+					}
 					try {
 						processRule(entry.getValue());
 					} catch (Exception e) {

--- a/cat-home/src/main/java/com/dianping/cat/report/alert/exception/ExceptionAlert.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/alert/exception/ExceptionAlert.java
@@ -81,6 +81,11 @@ public class ExceptionAlert implements Task {
 	private void handleExceptions(List<Item> itemList) {
 		Map<String, List<AlertException>> alertExceptions = m_alertBuilder.buildAlertExceptions(itemList);
 
+		//告警开关
+		if (alertExceptions.isEmpty()) {
+			return;
+		}
+
 		for (Entry<String, List<AlertException>> entry : alertExceptions.entrySet()) {
 			try {
 				String domain = entry.getKey();

--- a/cat-home/src/main/java/com/dianping/cat/report/alert/heartbeat/HeartbeatAlert.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/alert/heartbeat/HeartbeatAlert.java
@@ -250,6 +250,9 @@ public class HeartbeatAlert implements Task {
 	private void processDomain(String domain) {
 		int minute = calAlreadyMinute();
 		Map<String, List<Config>> configsMap = m_ruleConfigManager.queryConfigsByDomain(domain);
+		if (null == configsMap) {
+			return;
+		}
 		int domainMaxMinute = calMaxMinute(configsMap);
 		HeartbeatReport currentReport = null;
 		HeartbeatReport lastReport = null;

--- a/cat-home/src/main/java/com/dianping/cat/report/alert/heartbeat/HeartbeatRuleConfigManager.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/alert/heartbeat/HeartbeatRuleConfigManager.java
@@ -85,6 +85,9 @@ public class HeartbeatRuleConfigManager extends BaseRuleConfigManager implements
 		Map<String, Map<Integer, List<Rule>>> rules = new HashMap<String, Map<Integer, List<Rule>>>();
 
 		for (Rule rule : m_config.getRules().values()) {
+			if (rule.getAvailable() != null && !rule.getAvailable()) {
+				continue;
+			}
 			for (MetricItem metricItem : rule.getMetricItems()) {
 				String domainPattern = metricItem.getProductText();
 				int matchLevel = validateRegex(domainPattern, domain);
@@ -96,7 +99,9 @@ public class HeartbeatRuleConfigManager extends BaseRuleConfigManager implements
 				}
 			}
 		}
-
+		if (rules.size() == 0) {
+			return null;
+		}
 		return extractConfigs(domain, rules);
 	}
 

--- a/cat-home/src/main/java/com/dianping/cat/report/alert/spi/config/BaseRuleConfigManager.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/alert/spi/config/BaseRuleConfigManager.java
@@ -393,6 +393,23 @@ public abstract class BaseRuleConfigManager {
 		return m_config.toString();
 	}
 
+	public String updateRule(String id, String metricsStr, String configsStr,
+							 Boolean available) throws Exception {
+		Rule rule = new Rule(id);
+		rule.setAvailable(available);
+		List<MetricItem> metricItems = DefaultJsonParser.parseArray(MetricItem.class, metricsStr);
+		List<Config> configs = DefaultJsonParser.parseArray(Config.class, configsStr);
+		for (MetricItem metricItem : metricItems) {
+			rule.addMetricItem(metricItem);
+		}
+		for (Config config : configs) {
+			rule.addConfig(config);
+		}
+		decorateConfigOnStore(rule.getConfigs());
+		m_config.getRules().put(id, rule);
+		return m_config.toString();
+	}
+
 	public int validate(String productText, String metricKeyText, String product, String metricKey) {
 		int groupMatchResult = validateRegex(productText, product);
 

--- a/cat-home/src/main/java/com/dianping/cat/report/alert/transaction/TransactionAlert.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/alert/transaction/TransactionAlert.java
@@ -274,6 +274,10 @@ public class TransactionAlert implements Task, LogEnabled {
 				Map<String, Rule> rules = monitorRules.getRules();
 
 				for (Entry<String, Rule> entry : rules.entrySet()) {
+					//告警开关
+					if (!entry.getValue().getAvailable()) {
+						continue;
+					}
 					try {
 						processRule(entry.getValue());
 					} catch (Exception e) {

--- a/cat-home/src/main/java/com/dianping/cat/system/page/config/Model.java
+++ b/cat-home/src/main/java/com/dianping/cat/system/page/config/Model.java
@@ -85,6 +85,8 @@ public class Model extends ViewModel<SystemPage, Action, Context> {
 
 	private String m_id;
 
+	private Boolean m_available = true;
+
 	private String m_duplicateDomains;
 
 	private List<String> m_tags;
@@ -278,6 +280,14 @@ public class Model extends ViewModel<SystemPage, Action, Context> {
 
 	public void setId(String id) {
 		m_id = id;
+	}
+
+	public Boolean getAvailable() {
+		return m_available;
+	}
+
+	public void setAvailable(Boolean available) {
+		this.m_available = available;
 	}
 
 	public String getIpAddress() {

--- a/cat-home/src/main/java/com/dianping/cat/system/page/config/Payload.java
+++ b/cat-home/src/main/java/com/dianping/cat/system/page/config/Payload.java
@@ -103,6 +103,9 @@ public class Payload implements ActionPayload<SystemPage, Action> {
 	@FieldMeta("ruleId")
 	private String m_ruleId;
 
+	@FieldMeta("available")
+	private Boolean m_available;
+
 	@FieldMeta("metrics")
 	private String m_metrics;
 
@@ -347,6 +350,14 @@ public class Payload implements ActionPayload<SystemPage, Action> {
 
 	public void setRuleId(String ruleId) {
 		m_ruleId = ruleId;
+	}
+
+	public Boolean getAvailable() {
+		return m_available;
+	}
+
+	public void setAvailable(Boolean available) {
+		m_available = available;
 	}
 
 	public String getSumTags() {

--- a/cat-home/src/main/java/com/dianping/cat/system/page/config/processor/BaseProcesser.java
+++ b/cat-home/src/main/java/com/dianping/cat/system/page/config/processor/BaseProcesser.java
@@ -49,6 +49,18 @@ public class BaseProcesser {
 		}
 	}
 
+	public boolean addSubmitRule(BaseRuleConfigManager manager, String id, String metrics,
+								 String configs, Boolean available) {
+		try {
+			String xmlContent = manager.updateRule(id, metrics, configs, available);
+
+			return manager.insert(xmlContent);
+		} catch (Exception ex) {
+			Cat.logError(ex);
+			return false;
+		}
+	}
+
 	public boolean deleteRule(BaseRuleConfigManager manager, String key) {
 		try {
 			String xmlContent = manager.deleteRule(key);
@@ -69,6 +81,10 @@ public class BaseProcesser {
 				ruleId = rule.getId();
 				configsStr = new DefaultJsonBuilder(true).buildArray(rule.getConfigs());
 				String configHeader = new DefaultJsonBuilder(true).buildArray(rule.getMetricItems());
+
+				if (null != rule.getAvailable()) {
+					model.setAvailable(rule.getAvailable());
+				}
 
 				model.setConfigHeader(configHeader);
 			}
@@ -93,6 +109,12 @@ public class BaseProcesser {
 				String metricText = item.getMetricItemText();
 				RuleItem ruleItem = new RuleItem(id, productText, metricText);
 
+				if (null == rule.getAvailable()) {
+					ruleItem.setAvailable(true);
+				} else {
+					ruleItem.setAvailable(rule.getAvailable());
+				}
+
 				ruleItem.setMonitorCount(item.isMonitorCount());
 				ruleItem.setMonitorAvg(item.isMonitorAvg());
 				ruleItem.setMonitorSum(item.isMonitorSum());
@@ -105,6 +127,8 @@ public class BaseProcesser {
 
 	public class RuleItem {
 		private String m_id;
+
+		private boolean m_available;
 
 		private String m_productlineText;
 
@@ -128,6 +152,14 @@ public class BaseProcesser {
 
 		public void setId(String id) {
 			m_id = id;
+		}
+
+		public boolean isAvailable() {
+			return m_available;
+		}
+
+		public void setAvailable(boolean available) {
+			m_available = available;
 		}
 
 		public String getMetricText() {

--- a/cat-home/src/main/java/com/dianping/cat/system/page/config/processor/EventConfigProcessor.java
+++ b/cat-home/src/main/java/com/dianping/cat/system/page/config/processor/EventConfigProcessor.java
@@ -18,8 +18,11 @@
  */
 package com.dianping.cat.system.page.config.processor;
 
+import java.util.Map;
+
 import org.unidal.lookup.annotation.Inject;
 
+import com.dianping.cat.alarm.rule.entity.Rule;
 import com.dianping.cat.report.alert.event.EventRuleConfigManager;
 import com.dianping.cat.system.page.config.Action;
 import com.dianping.cat.system.page.config.Model;
@@ -33,13 +36,16 @@ public class EventConfigProcessor extends BaseProcesser {
 	public void process(Action action, Payload payload, Model model) {
 		switch (action) {
 		case EVENT_RULE:
-			model.setRules(m_configManager.getMonitorRules().getRules().values());
+			Map<String, Rule> ruleMap = m_configManager.getMonitorRules().getRules();
+			rulesAvailableBuild(ruleMap);
+			model.setRules(ruleMap.values());
 			break;
 		case EVENT_RULE_ADD_OR_UPDATE:
 			generateRuleConfigContent(payload.getRuleId(), m_configManager, model);
 			break;
 		case EVENT_RULE_ADD_OR_UPDATE_SUBMIT:
-			model.setOpState(addSubmitRule(m_configManager, payload.getRuleId(), "", payload.getConfigs()));
+			model.setOpState(addSubmitRule(m_configManager, payload.getRuleId(), "",
+					payload.getConfigs(), payload.getAvailable()));
 			model.setRules(m_configManager.getMonitorRules().getRules().values());
 			break;
 		case EVENT_RULE_DELETE:
@@ -51,4 +57,15 @@ public class EventConfigProcessor extends BaseProcesser {
 		}
 	}
 
+	//增加告警开关功能，但是线上并无available值，这里做一个兼容
+	private void rulesAvailableBuild(Map<String, Rule> ruleMap) {
+		if (ruleMap == null || ruleMap.isEmpty()) {
+			return;
+		}
+		for (Rule rule : ruleMap.values()) {
+			if (null == rule.getAvailable()) {
+				rule.setAvailable(true);
+			}
+		}
+	}
 }

--- a/cat-home/src/main/java/com/dianping/cat/system/page/config/processor/ExceptionConfigProcessor.java
+++ b/cat-home/src/main/java/com/dianping/cat/system/page/config/processor/ExceptionConfigProcessor.java
@@ -49,7 +49,23 @@ public class ExceptionConfigProcessor {
 
 	private void loadExceptionConfig(Model model) {
 		model.setExceptionExcludes(m_exceptionRuleConfigManager.queryAllExceptionExcludes());
-		model.setExceptionLimits(m_exceptionRuleConfigManager.queryAllExceptionLimits());
+
+		List<ExceptionLimit> exceptionLimits = m_exceptionRuleConfigManager
+				.queryAllExceptionLimits();
+		rulesAvailableBuild(exceptionLimits);
+		model.setExceptionLimits(exceptionLimits);
+	}
+
+	//增加告警开关功能，但是线上并无available值，这里做一个兼容
+	private void rulesAvailableBuild(List<ExceptionLimit> exceptionLimits) {
+		if (exceptionLimits == null || exceptionLimits.isEmpty()) {
+			return;
+		}
+		for (ExceptionLimit exceptionLimit : exceptionLimits) {
+			if (null == exceptionLimit.getAvailable()) {
+				exceptionLimit.setAvailable(true);
+			}
+		}
 	}
 
 	public void process(Action action, Payload payload, Model model) {
@@ -114,6 +130,7 @@ public class ExceptionConfigProcessor {
 		limit.setDomain(limit.getDomain().trim());
 		limit.setName(limit.getName().trim());
 		limit.setId(limit.getDomain() + ":" + limit.getName());
+		limit.setAvailable(limit.getAvailable());
 
 		if (StringUtils.isNotEmpty(limit.getDomain()) && StringUtils.isNotEmpty(limit.getName())) {
 			m_exceptionRuleConfigManager.insertExceptionLimit(limit);

--- a/cat-home/src/main/java/com/dianping/cat/system/page/config/processor/HeartbeatConfigProcessor.java
+++ b/cat-home/src/main/java/com/dianping/cat/system/page/config/processor/HeartbeatConfigProcessor.java
@@ -49,8 +49,8 @@ public class HeartbeatConfigProcessor extends BaseProcesser {
 			generateRuleConfigContent(payload.getKey(), m_heartbeatRuleConfigManager, model);
 			break;
 		case HEARTBEAT_RULE_ADD_OR_UPDATE_SUBMIT:
-			model.setOpState(
-									addSubmitRule(m_heartbeatRuleConfigManager, payload.getRuleId(), payload.getMetrics(),	payload.getConfigs()));
+			model.setOpState(addSubmitRule(m_heartbeatRuleConfigManager, payload.getRuleId(),
+					payload.getMetrics(), payload.getConfigs(), payload.getAvailable()));
 			generateRuleItemList(m_heartbeatRuleConfigManager, model);
 			break;
 		case HEARTBEAT_RULE_DELETE:

--- a/cat-home/src/main/java/com/dianping/cat/system/page/config/processor/TransactionConfigProcessor.java
+++ b/cat-home/src/main/java/com/dianping/cat/system/page/config/processor/TransactionConfigProcessor.java
@@ -18,8 +18,11 @@
  */
 package com.dianping.cat.system.page.config.processor;
 
+import java.util.Map;
+
 import org.unidal.lookup.annotation.Inject;
 
+import com.dianping.cat.alarm.rule.entity.Rule;
 import com.dianping.cat.report.alert.transaction.TransactionRuleConfigManager;
 import com.dianping.cat.system.page.config.Action;
 import com.dianping.cat.system.page.config.Model;
@@ -33,13 +36,16 @@ public class TransactionConfigProcessor extends BaseProcesser {
 	public void process(Action action, Payload payload, Model model) {
 		switch (action) {
 		case TRANSACTION_RULE:
-			model.setRules(m_configManager.getMonitorRules().getRules().values());
+			Map<String, Rule> ruleMap = m_configManager.getMonitorRules().getRules();
+			rulesAvailableBuild(ruleMap);
+			model.setRules(ruleMap.values());
 			break;
 		case TRANSACTION_RULE_ADD_OR_UPDATE:
 			generateRuleConfigContent(payload.getRuleId(), m_configManager, model);
 			break;
 		case TRANSACTION_RULE_ADD_OR_UPDATE_SUBMIT:
-			model.setOpState(addSubmitRule(m_configManager, payload.getRuleId(), "", payload.getConfigs()));
+			model.setOpState(addSubmitRule(m_configManager, payload.getRuleId(), "",
+					payload.getConfigs(), payload.getAvailable()));
 			model.setRules(m_configManager.getMonitorRules().getRules().values());
 			break;
 		case TRANSACTION_RULE_DELETE:
@@ -51,4 +57,15 @@ public class TransactionConfigProcessor extends BaseProcesser {
 		}
 	}
 
+	//增加告警开关功能，但是线上并无available值，这里做一个兼容
+	private void rulesAvailableBuild(Map<String, Rule> ruleMap) {
+		if (ruleMap == null || ruleMap.isEmpty()) {
+			return;
+		}
+		for (Rule rule : ruleMap.values()) {
+			if (null == rule.getAvailable()) {
+				rule.setAvailable(true);
+			}
+		}
+	}
 }

--- a/cat-home/src/main/resources/META-INF/dal/model/exception-rule-config-codegen.xml
+++ b/cat-home/src/main/resources/META-INF/dal/model/exception-rule-config-codegen.xml
@@ -10,6 +10,7 @@
     <attribute name="name" value-type="String" />
     <attribute name="warning" value-type="int" />
     <attribute name="error" value-type="int" />
+    <attribute name="available" value-type="boolean"/>
   </entity>
   <entity name="exception-exclude">
     <attribute name="id" value-type="String" />

--- a/cat-home/src/main/resources/META-INF/dal/model/exception-rule-config-model.xml
+++ b/cat-home/src/main/resources/META-INF/dal/model/exception-rule-config-model.xml
@@ -11,6 +11,7 @@
     <attribute name="name" value-type="String" />
     <attribute name="warning" value-type="int" primitive="true" />
     <attribute name="error" value-type="int" primitive="true" />
+    <attribute name="available" value-type="boolean"/>
   </entity>
   <entity name="exception-exclude">
     <attribute name="id" value-type="String" key="true" />

--- a/cat-home/src/main/webapp/jsp/system/eventRule/eventRule.jsp
+++ b/cat-home/src/main/webapp/jsp/system/eventRule/eventRule.jsp
@@ -14,9 +14,10 @@
 			<thead>
 				<tr >
 					<th width="20%">项目组</th>
-					<th width="30%">Type</th>
+					<th width="20%">Type</th>
 					<th width="20%">Name</th>
 					<th width="20%">监控项</th>
+					<th width="10%">是否告警</th>
 					<th width="10%">操作 <a href="?op=eventRuleUpdate" class="btn btn-primary btn-xs" >
 						<i class="ace-icon glyphicon glyphicon-plus bigger-120"></i></a></th>
 				</tr></thead><tbody>
@@ -32,6 +33,16 @@
 						<td>${type}</td>
 						<td>${name}</td>
 						<td>${monitor}</td>
+                        <td>
+                            <c:choose>
+                                <c:when test="${item.available == false}">
+                                    <span>否</span>
+                                </c:when>
+                                <c:otherwise>
+                                    <span class="text-danger">是</span>
+                                </c:otherwise>
+                            </c:choose>
+                        </td>
 						<td><a href="?op=eventRuleUpdate&ruleId=${item.id}" class="btn btn-primary btn-xs">
 						<i class="ace-icon fa fa-pencil-square-o bigger-120"></i></a>
 						<a href="?op=eventRuleDelete&ruleId=${item.id}" class="btn btn-danger btn-xs delete" >

--- a/cat-home/src/main/webapp/jsp/system/eventRule/eventRuleUpdate.jsp
+++ b/cat-home/src/main/webapp/jsp/system/eventRule/eventRuleUpdate.jsp
@@ -26,6 +26,17 @@
 													<option value="count">执行次数</option>
 								                	<option value="failRatio">失败率</option>
 								            	</select>
+                    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;是否告警&nbsp;&nbsp;
+                                            <c:choose>
+                                                <c:when test="${model.available}">
+                                                    <input type="radio" name="event.available" value="true" checked />是&nbsp;&nbsp;&nbsp;
+                                                    <input type="radio" name="event.available" value="false" />否
+                                                </c:when>
+                                                <c:otherwise>
+                                                    <input type="radio" name="event.available" value="true" />是&nbsp;&nbsp;&nbsp;
+                                                    <input type="radio" name="event.available" value="false" checked />否
+                                                </c:otherwise>
+                                            </c:choose>
 				</tr>
 				<tr><th>${model.content}</th></tr>
 					<tr>
@@ -57,11 +68,13 @@ function update() {
 		name = "All";
 		$("#domain").val("All");
 	}
+
+	var available = $("input[name='event.available']:checked").val();
     
     var monitor = $("#monitor").val();
     var split = ";";
     var id = domain + split + type + split + name + split + monitor;
-    window.location.href = "?op=eventRuleSubmit&configs=" + encodeURIComponent(configStr) + "&ruleId=" + encodeURIComponent(id);
+    window.location.href = "?op=eventRuleSubmit&configs=" + encodeURIComponent(configStr) + "&ruleId=" + encodeURIComponent(id) + "&available=" + encodeURIComponent(available);
 }
 
 	$(document).ready(function() {

--- a/cat-home/src/main/webapp/jsp/system/exception/exception.jsp
+++ b/cat-home/src/main/webapp/jsp/system/exception/exception.jsp
@@ -61,9 +61,10 @@
 							<thead>
 								<tr >
 									<th width="25%">域名</th>
-									<th width="45%">异常名称</th>
+									<th width="37%">异常名称</th>
 									<th width="12%">Warning阈值</th>
 									<th width="10%">Error阈值</th>
+									<th width="8%">是否告警</th>
 									<th width="8%">操作 <a href="?op=exceptionThresholdAdd" class="btn btn-primary btn-xs" >
 						<i class="ace-icon glyphicon glyphicon-plus bigger-120"></i></a></th>
 										
@@ -77,6 +78,16 @@
 										<td>${item.name}</td>
 										<td>${item.warning}</td>
 										<td>${item.error}</td>
+										<td>
+                                            <c:choose>
+                                                <c:when test="${item.available == false}">
+                                                    <span>否</span>
+                                                </c:when>
+                                                <c:otherwise>
+                                                    <span class="text-danger">是</span>
+                                                </c:otherwise>
+                                            </c:choose>
+                                        </td>
 										<td>
 							<a href="?op=exceptionThresholdUpdate&domain=${item.domain}&exception=${item.name}" class="btn btn-primary btn-xs">
 						<i class="ace-icon fa fa-pencil-square-o bigger-120"></i></a>

--- a/cat-home/src/main/webapp/jsp/system/exception/exceptionThresholdConfig.jsp
+++ b/cat-home/src/main/webapp/jsp/system/exception/exceptionThresholdConfig.jsp
@@ -116,6 +116,25 @@
 			<td><input id="errorThreshold" name="exceptionLimit.error"
 				value="${model.exceptionLimit.error}" required /><span class="text-danger">&nbsp;&nbsp;*</span>（仅支持数字）</td>
 		</tr>
+
+
+        <tr>
+            <td style="text-align: right" class="text-success" width="20%">是否告警</td>
+            <td>
+                <c:choose>
+                    <c:when test="${model.exceptionLimit.available}">
+                        <input type="radio" name="exceptionLimit.available" value="true" checked />是&nbsp;&nbsp;&nbsp;
+                        <input type="radio" name="exceptionLimit.available" value="false" />否
+                    </c:when>
+                    <c:otherwise>
+                        <input type="radio" name="exceptionLimit.available" value="true" />是&nbsp;&nbsp;&nbsp;
+                        <input type="radio" name="exceptionLimit.available" value="false" checked />否
+                    </c:otherwise>
+                </c:choose>
+                <span class="text-danger">&nbsp;&nbsp;*</span>
+            </td>
+        </tr>
+
 		<tr>
 			<td colspan='2'  style="text-align:center"><input class='btn btn-primary' id="addOrUpdateExceptionConfigSubmit" type="submit"
 				name="submit" value="提交"/></td>

--- a/cat-home/src/main/webapp/jsp/system/heartbeat/heartbeatConfigs.jsp
+++ b/cat-home/src/main/webapp/jsp/system/heartbeat/heartbeatConfigs.jsp
@@ -34,7 +34,8 @@
 	     		<thead><tr>
 	     			<th width="30%">规则id</th>
 	     			<th width="26%">项目配置</th>
-	     			<th width="29%">指标配置</th>
+	     			<th width="21%">指标配置</th>
+	     			<th width="8%">是否告警</th>
 	     			<th width="8%">操作 <a href="?op=heartbeatRuleUpdate&key=${item.id}" class="btn btn-primary btn-xs" >
 						<i class="ace-icon glyphicon glyphicon-plus bigger-120"></i></a></th>
 	     		</tr></thead>
@@ -43,6 +44,16 @@
 	     			<td>${item.id}</td>
 	     			<td>${item.productlineText}</td>
 	     			<td>${item.metricText}</td>
+                    <td>
+                        <c:choose>
+                            <c:when test="${item.available == false}">
+                                <span>否</span>
+                            </c:when>
+                            <c:otherwise>
+                                <span class="text-danger">是</span>
+                            </c:otherwise>
+                        </c:choose>
+                    </td>
 			     	<td><a href="?op=heartbeatRuleUpdate&key=${item.id}" class="btn btn-primary btn-xs">
 						<i class="ace-icon fa fa-pencil-square-o bigger-120"></i></a>
 						<a href="?op=heartbeatRulDelete&key=${item.id}" class="btn btn-danger btn-xs delete" >

--- a/cat-home/src/main/webapp/jsp/system/heartbeat/heartbeatRuleAdd.jsp
+++ b/cat-home/src/main/webapp/jsp/system/heartbeat/heartbeatRuleAdd.jsp
@@ -20,6 +20,17 @@
 				
 				<div class="config">
 				<strong class="text-success">规则ID</strong> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input id="ruleId" type="text" value="${model.id}" /> <span class="text-danger">String，唯一性</span>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;是否告警&nbsp;&nbsp;
+                                        <c:choose>
+                                            <c:when test="${model.available}">
+                                                <input type="radio" name="heartbeat.available" value="true" checked />是&nbsp;&nbsp;&nbsp;
+                                                <input type="radio" name="heartbeat.available" value="false" />否
+                                            </c:when>
+                                            <c:otherwise>
+                                                <input type="radio" name="heartbeat.available" value="true" />是&nbsp;&nbsp;&nbsp;
+                                                <input type="radio" name="heartbeat.available" value="false" checked />否
+                                            </c:otherwise>
+                                        </c:choose>
 				</div>
 				<div id="metrics" class="config">
 					<button class="btn btn-success btn-xs" id="add-metric-button" type="button">
@@ -135,7 +146,8 @@
 				var key = $('#ruleId').val();
 				var metrics = generateMetricsJsonString();
 				var configStr = generateConfigsJsonString();
-			    window.location.href = "?op=heartbeatRuleSubmit&configs=" + encodeURIComponent(configStr) + "&ruleId=" + encodeURIComponent(key) +"&metrics=" + encodeURIComponent(metrics);
+				var available = $("input[name='heartbeat.available']:checked").val();
+			    window.location.href = "?op=heartbeatRuleSubmit&configs=" + encodeURIComponent(configStr) + "&ruleId=" + encodeURIComponent(key) +"&metrics=" + encodeURIComponent(metrics) + "&available=" + encodeURIComponent(available);
 			});
 			
 			$("#add-metric-button").click(function(){

--- a/cat-home/src/main/webapp/jsp/system/transactionRule/transactionRule.jsp
+++ b/cat-home/src/main/webapp/jsp/system/transactionRule/transactionRule.jsp
@@ -14,9 +14,10 @@
 			<thead>
 				<tr >
 					<th width="20%">项目组</th>
-					<th width="30%">Type</th>
+					<th width="20%">Type</th>
 					<th width="20%">Name</th>
 					<th width="20%">监控项</th>
+					<th width="10%">是否告警</th>
 					<th width="10%">操作 <a href="?op=transactionRuleUpdate" class="btn btn-primary btn-xs" >
 						<i class="ace-icon glyphicon glyphicon-plus bigger-120"></i></a></th>
 				</tr></thead><tbody>
@@ -32,6 +33,16 @@
 						<td>${type}</td>
 						<td>${name}</td>
 						<td>${monitor}</td>
+						<td>
+                            <c:choose>
+                                <c:when test="${item.available == false}">
+                                    <span>否</span>
+                                </c:when>
+                                <c:otherwise>
+                                    <span class="text-danger">是</span>
+                                </c:otherwise>
+                            </c:choose>
+                        </td>
 						<td><a href="?op=transactionRuleUpdate&ruleId=${item.id}" class="btn btn-primary btn-xs">
 						<i class="ace-icon fa fa-pencil-square-o bigger-120"></i></a>
 						<a href="?op=transactionRuleDelete&ruleId=${item.id}" class="btn btn-danger btn-xs delete" >

--- a/cat-home/src/main/webapp/jsp/system/transactionRule/transactionRuleUpdate.jsp
+++ b/cat-home/src/main/webapp/jsp/system/transactionRule/transactionRuleUpdate.jsp
@@ -28,6 +28,17 @@
 								                	<option value="failRatio">失败率</option>
 								                	<option value="max">最大响应时间</option>
 								            	</select>
+                    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;是否告警&nbsp;&nbsp;
+                                                                <c:choose>
+                                                                    <c:when test="${model.available}">
+                                                                        <input type="radio" name="transaction.available" value="true" checked />是&nbsp;&nbsp;&nbsp;
+                                                                        <input type="radio" name="transaction.available" value="false" />否
+                                                                    </c:when>
+                                                                    <c:otherwise>
+                                                                        <input type="radio" name="transaction.available" value="true" />是&nbsp;&nbsp;&nbsp;
+                                                                        <input type="radio" name="transaction.available" value="false" checked />否
+                                                                    </c:otherwise>
+                                                                </c:choose>
 				</tr>
 				<tr><th>${model.content}</th></tr>
 					<tr>
@@ -59,11 +70,13 @@ function update() {
 		name = "All";
 		$("#domain").val("All");
 	}
+
+	var available = $("input[name='transaction.available']:checked").val();
     
     var monitor = $("#monitor").val();
     var split = ";";
     var id = domain + split + type + split + name + split + monitor;
-    window.location.href = "?op=transactionRuleSubmit&configs=" + encodeURIComponent(configStr) + "&ruleId=" + encodeURIComponent(id);
+    window.location.href = "?op=transactionRuleSubmit&configs=" + encodeURIComponent(configStr) + "&ruleId=" + encodeURIComponent(id) + "&available=" + encodeURIComponent(available);
 }
 
 	$(document).ready(function() {


### PR DESCRIPTION
★首先，非常赞赏CAT团队能够做出如此完善的业务监控体系，各种配置的便捷性使我们十分受益。

★我们在使用CAT3.0的过程中，对一些功能进行了定制，使某些功能在应用中更加合理。本着取自开源，回馈开源的想法，本次将Transaction告警、Event告警、心跳告警、异常告警中对各个告警配置项的细化开关贡献到原项目，此功能可在不删除配置项的情况下，动态启停各告警配置。

★部分界面如下：
![image](https://user-images.githubusercontent.com/26428832/65220087-85985200-daec-11e9-84d2-2c8b62ae51b6.png)
![image](https://user-images.githubusercontent.com/26428832/65220768-128fdb00-daee-11e9-8fdf-0174f8911bd9.png)
![image](https://user-images.githubusercontent.com/26428832/65220785-20456080-daee-11e9-8b68-6d6c11c4b34f.png)