### PR TITLE
Add dokcer host mode

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     ports:
       - "8080:8080"
       - "2280:2280"
+    network_mode: "host"
 
   # disable this if you have your own mysql
   mysql:


### PR DESCRIPTION
# 描述
以Docker容器进行集群部署时，cat服务端的ip会解析为容器ip，一般为172.17.0.x，而不是服务器的外网ip（集群内网ip）。此时如果以外网ip配置集群，各服务端间可以同步配置和同时消费，但是各个cat服务端都无法正确解析自身的ip（个人推测），首页出现 **出问题的cat的服务端[xx,xx]**
* cat-server: 3570b06a392d8a0f21a33890e2f7759584a36855(commit id)
* cat-client: 3.0.0
* server os: Linux pre0 4.4.0-142-generic #168-Ubuntu SMP Wed Jan 16 21:00:45 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux

# 复现
1. docker快速部署
2. 以外网ip配置客户端路由和服务端配置
3. 首页出现 **出问题的cat的服务端[xx,xx]**
# Fix
更改Docker容器的网络模式为host，即容器共用服务器的外网Ip