### PR TITLE
【bug fix】transaction页面不能正确显示分组样式

### DIFF
--- a/cat-home/src/main/webapp/jsp/report/transaction/transactionGroup.jsp
+++ b/cat-home/src/main/webapp/jsp/report/transaction/transactionGroup.jsp
@@ -67,7 +67,7 @@
 		$.each($('table.machines a'), function(index, item) {
 			var id = $(item).text();
 			<c:forEach var="ip" items="${model.groupIps}">
-			group = '${ip} ';
+			group = '${ip}';
 			if(id.indexOf(group)!=-1){
 					$(item).addClass('current');
 			}


### PR DESCRIPTION
有分组时获取分组ip多了个空格导致分组ip无法高亮