### PR TITLE
支持使用export CAT_HOME=xxxx指定 c版本的客户端的CAT_HOME路径

### DIFF
--- a/lib/c/src/ccat/client.c
+++ b/lib/c/src/ccat/client.c
@@ -21,6 +21,9 @@
 #include <lib/cat_clog.h>
 #include <lib/cat_time_util.h>
 #include <ccat/version.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "client_config.h"
 #include "context.h"
@@ -121,7 +124,18 @@ int catClientInitWithConfig(const char *appkey, CatClientConfig* config) {
 
     initCatClientConfig(config);
 
-    if (loadCatClientConfig(DEFAULT_XML_FILE) < 0) {
+    char *cathomevar;
+    cathomevar = catHome();
+    printf("Using CAT_HOME=%s\n", cathomevar);
+
+    // char *clientXML = cathomevar + 'client.xml';
+    char *clientXMLFileName = "client.xml";
+    char *clientXML = (char *) malloc(strlen(cathomevar) + strlen(clientXMLFileName));
+    sprintf(clientXML, "%s%s", cathomevar, clientXMLFileName);
+
+    printf("Using client xml=%s\n", clientXML);
+
+    if (loadCatClientConfig(clientXML) < 0) {
         g_cat_init = 0;
         g_cat_enabled = 0;
         INNER_LOG(CLOG_ERROR, "Failed to initialize cat: Error occurred while loading client config.");

--- a/lib/c/src/ccat/client_config.c
+++ b/lib/c/src/ccat/client_config.c
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 #include "client_config.h"
+#include <stdlib.h>
 
 #include <lib/cat_clog.h>
 #include <lib/cat_ezxml.h>
@@ -154,7 +155,13 @@ void initCatClientConfig(CatClientConfig *config) {
     g_config.logLevel = CLOG_ALL;
 
     g_config.configDir = catsdsnew("./");
-    g_config.dataDir = catsdsnew(DEFAULT_DATA_DIR);
+
+    // CAT_HOME
+    char *cathomevar;
+    cathomevar = catHome();
+    const char *dataDir = cathomevar;
+    printf("Using dataDir=%s\n", dataDir);
+    g_config.dataDir = catsdsnew(dataDir);
 
     g_config.indexFileName = catsdsnew("client.idx.h");
 
@@ -195,3 +202,13 @@ void clearCatClientConfig() {
     catsdsfree(g_config.indexFileName);
 }
 
+
+char *catHome() {
+       // CAT_HOME
+    char *cathomevar;
+    cathomevar = getenv("CAT_HOME");
+    if (cathomevar == NULL) {
+        cathomevar = DEFAULT_CAT_HOME;
+    }
+    return cathomevar;
+}

--- a/lib/c/src/ccat/client_config.h
+++ b/lib/c/src/ccat/client_config.h
@@ -66,13 +66,16 @@ typedef struct _CatClientInnerConfig {
 #define DEFAULT_IP "127.0.0.1"
 #define DEFAULT_IP_HEX "7f000001"
 
-#define DEFAULT_XML_FILE "/data/appdatas/cat/client.xml"
+// #define DEFAULT_XML_FILE "/data/appdatas/cat/client.xml"
 
-#if defined(__linux__) || defined(__APPLE__)
-#define DEFAULT_DATA_DIR "/data/appdatas/cat/"
-#else
-#define DEFAULT_DATA_DIR "./"
-#endif
+// 通过指定环境变量CAT_HOME来修改此路径
+#define DEFAULT_CAT_HOME "/data/appdatas/cat/"
+
+// #if defined(__linux__) || defined(__APPLE__)
+// #define DEFAULT_DATA_DIR "/data/appdatas/cat/"
+// #else
+// #define DEFAULT_DATA_DIR "./"
+// #endif
 
 extern CatClientInnerConfig g_config;
 
@@ -83,5 +86,7 @@ void initCatClientConfig(CatClientConfig *config);
 void clearCatClientConfig();
 
 void catChecktPtrWithName(void *ptr, char *ptrName);
+
+char *catHome();
 
 #endif //CAT_CLIENT_C_CLIENT_CONFIG_H

--- a/lib/c/src/lib/cat_clog.c
+++ b/lib/c/src/lib/cat_clog.c
@@ -17,6 +17,9 @@
  * limitations under the License.
  */
 #include "cat_clog.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "lib/headers.h"
 #include "lib/cat_time_util.h"
@@ -69,7 +72,18 @@ static int CLogUpdateSaveFile() {
         }
 
         char logName[512] = {'\0'};
-        strncat(logName, g_log_save_filepath, 256);
+        
+        char *logFilePrefix;
+        char *cathomevar;
+        cathomevar = getenv("CAT_HOME");
+        if (cathomevar == NULL) {
+            logFilePrefix = g_log_save_filepath;
+        } else {
+            logFilePrefix = (char *) malloc(strlen(cathomevar) + strlen("catlog"));
+            sprintf(logFilePrefix, "%s%s", cathomevar, "catlog");
+        }
+        strncat(logName, logFilePrefix, 256);
+
         if (g_log_file_perDay) {
             _CLog_datePostfix(logName + strlen(logName), 128);
         }
@@ -77,7 +91,7 @@ static int CLogUpdateSaveFile() {
             strncat(logName, GetDetailTimeString(0), 64);
         }
         strncat(logName, ".log", 64);
-
+        printf("Using cat log file=%s", logName);
         g_innerLog->m_f_logOut = fopen(logName, "a+");
         if (NULL == g_innerLog->m_f_logOut) {
             _CLog_debugInfo("Log file has been opened in write mode by other process.\n");


### PR DESCRIPTION
1. 可指定CAT_HOME环境变量，c版本的sdk将优先使用此配置，例如 export CAT_HOME=/tmp/cat/
2. 对于sdk的日志，也将使用CAT_HOME环境变量的位置，日志写入到 ${CAT_HOME}catlog_2019_12_03.log文件中