### PR TITLE
系统有网卡未配置IP 会 coredump

### DIFF
--- a/lib/c/src/lib/cat_network_util.c
+++ b/lib/c/src/lib/cat_network_util.c
@@ -72,7 +72,9 @@ int getLocalHostIp(char *ip) {
     struct ifaddrs *ifa;
     for (ifa = ifaddrs; NULL != ifa; ifa = ifa->ifa_next) {
         char hostname[NI_MAXHOST];
-
+        if (ifa->ifa_addr == NULL) {
+            continue;
+        }
         if (ifa->ifa_addr->sa_family == AF_INET) {
 
             // ignore not up interface.


### PR DESCRIPTION
复现：

https://stackoverflow.com/questions/22767155/when-will-ifa-addr-be-null-on-calling-getifaddrs