### PR TITLE
fix Cat.checkAndInitialize

### DIFF
--- a/lib/java/src/main/java/com/dianping/cat/Cat.java
+++ b/lib/java/src/main/java/com/dianping/cat/Cat.java
@@ -192,6 +192,9 @@ public class Cat {
     }
 
     public static MessageManager getManager() {
+        if (!isEnabled()) {
+            return NullMessageManager.NULL_MESSAGE_MANAGER;
+        }
         try {
             checkAndInitialize();
 
@@ -207,6 +210,9 @@ public class Cat {
     }
 
     public static MessageProducer getProducer() {
+        if (!isEnabled()) {
+            return NullMessageProducer.NULL_MESSAGE_PRODUCER;
+        }
         try {
             checkAndInitialize();
 
@@ -222,7 +228,9 @@ public class Cat {
     }
 
     public static void initialize() {
-        checkAndInitialize();
+        if (isEnabled()) {
+            checkAndInitialize();
+        }
     }
 
     public static void initialize(String... servers) {


### PR DESCRIPTION
issues reference : https://github.com/dianping/cat/issues/1889

FIX :  check isEnable before calling the follow method to avoid call checkAndInitialize method:
- getManager
- getProducer
- initialize
