### PR TITLE
修复mybatis插件无法记录PageHelper调用的问题

### DIFF
--- a/integration/mybatis/interceptor/CatMybatisInterceptor.java
+++ b/integration/mybatis/interceptor/CatMybatisInterceptor.java
@@ -28,7 +28,10 @@ import java.util.Properties;
 @Intercepts({
         @Signature(type = Executor.class, method = "update", args = {MappedStatement.class, Object.class}),
         @Signature(type = Executor.class, method = "query", args = {MappedStatement.class, Object.class,
-                RowBounds.class, ResultHandler.class})})
+                RowBounds.class, ResultHandler.class}),
+        @Signature(type = Executor.class, method = "query",
+                args = {MappedStatement.class, Object.class, RowBounds.class, ResultHandler.class, CacheKey.class, BoundSql.class}
+        )})
 public class CatMybatisInterceptor implements Interceptor {
 
     private Properties properties;


### PR DESCRIPTION
当使用PageHelper插件时，CatMybatisInterceptor无法拦截相关的调用，增加了一个拦截点。