### PR TITLE
fix table style problem

### DIFF
--- a/cat-home/src/main/webapp/css/body.css
+++ b/cat-home/src/main/webapp/css/body.css
@@ -14,8 +14,8 @@ th{
 	word-break: break-all;
 }
 td{
-	word-break: break-all;c
-	padding-left:3px;
+	word-break: break-all;
+	padding: 0 3px;
 }
 
 a.error {


### PR DESCRIPTION
body.css has an unexpected char 'c' which is the cause of the style that all table's td elements  are too close.
Especially in 'logview page', there are no space between type and name columns, status and raw message neither.

*Before* ~~`padding-left: 3px;`~~
![before](https://user-images.githubusercontent.com/8142133/80328363-adfde100-8871-11ea-90e5-f0bf0da9325c.png)
*After* `padding: 0 3px;`
![after](https://user-images.githubusercontent.com/8142133/80328369-b3f3c200-8871-11ea-96b2-4b0e03b0912f.png)

*Before* ~~`padding-left: 3px;`~~
![before2](https://user-images.githubusercontent.com/8142133/80328374-b9510c80-8871-11ea-817f-b82c49050653.png)
*After* `padding: 0 3px;`
![after2](https://user-images.githubusercontent.com/8142133/80328378-bbb36680-8871-11ea-90ea-a76349eb964f.png)

*padding-left only* `padding-left: 3px;`
![padding-left](https://user-images.githubusercontent.com/8142133/80328474-09c86a00-8872-11ea-9f09-df836ab310ae.png)


