### PR TITLE
修复 HttpStats 单例在并发环境下指令重排序问题

### DIFF
--- a/lib/java/src/main/java/com/dianping/cat/status/http/HttpStats.java
+++ b/lib/java/src/main/java/com/dianping/cat/status/http/HttpStats.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class HttpStats {
-    private static HttpStats current = null;
+    private static volatile HttpStats current = null;
     private AtomicInteger httpStatus400Count = new AtomicInteger();
     private AtomicInteger httpStatus500Count = new AtomicInteger();
     private AtomicInteger httpCount = new AtomicInteger();


### PR DESCRIPTION
禁止 `current = new HttpStats();`  指令重排序