### PR TITLE
fix(docker): 修复docker部署时LogView无法展示问题

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,3 +1,3 @@
 + DockerHub地址: https://hub.docker.com/r/meituaninc/cat
 + docker镜像打包
-  + 进入项目根目录：docker build -f docker/Dockerfile cat:{tag} .
+  + 进入项目根目录：docker build -f docker/Dockerfile -t cat:{tag} .

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - "./client.xml:/data/appdatas/cat/client.xml"
       # 默认使用环境变量设置。可以启用本注解，并修改为自己的配置
 #      - "./datasources.xml:/data/appdatas/cat/datasources.xml"
-    command: /bin/sh -c './datasources.sh && catalina.sh run'
+    command: /bin/sh -c 'ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2 && ./datasources.sh && catalina.sh run'
     links:
       - mysql
     depends_on:


### PR DESCRIPTION
主要解决了目前使用docker部署时出现LogView无法展示的问题
本来是想直接改Dockerfile，但是打包后发现基于目前master的代码，是会报500错误的，因此只改了docker-compose.yml，基于现有的情况修正，已测试通过

具体可以见这个issue:https://github.com/dianping/cat/issues/2242

感谢@hzhswyz