### PR TITLE
fix(sec): upgrade org.apache.commons:commons-email to 1.5

### DIFF
--- a/cat-home/pom.xml
+++ b/cat-home/pom.xml
@@ -89,7 +89,7 @@
       <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-email</artifactId>
-         <version>1.1</version>
+         <version>1.5</version>
       </dependency>
       <dependency>
          <groupId>javax.mail</groupId>
@@ -247,4 +247,3 @@
       <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
    </properties>
 </project>
-


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in org.apache.commons:commons-email 1.1
- [CVE-2017-9801](https://www.oscs1024.com/hd/CVE-2017-9801)
- [CVE-2018-1294](https://www.oscs1024.com/hd/CVE-2018-1294)


### What did I do？
Upgrade org.apache.commons:commons-email from 1.1 to 1.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS