### PR TITLE
fix(sec): upgrade org.freemarker:freemarker to 2.3.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.dianping.cat</groupId>
 	<artifactId>parent</artifactId>
@@ -189,7 +188,7 @@
 			<dependency>
 				<groupId>org.freemarker</groupId>
 				<artifactId>freemarker</artifactId>
-				<version>2.3.9</version>
+				<version>2.3.30</version>
 			</dependency>
 			<dependency>
 				<groupId>com.mchange.v2</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.freemarker:freemarker 2.3.9
- [MPS-2022-12438](https://www.oscs1024.com/hd/MPS-2022-12438)


### What did I do？
Upgrade org.freemarker:freemarker from 2.3.9 to 2.3.30 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS