### PR TITLE
feat(nodejs): cat 支持node12+以上版本编译

### DIFF
--- a/lib/node.js/src/nodecat.cc
+++ b/lib/node.js/src/nodecat.cc
@@ -5,105 +5,251 @@
 
 using namespace v8;
 using namespace std;
+#define MAJOR_VERSION NODE_MAJOR_VERSION
+#define MINOR_VERSION NODE_MINOR_VERSION
 
-namespace catapi {
+namespace catapi
+{
 
-    /**
-     * Initialize cat
-     * @param args
-     */
-    void Init(const FunctionCallbackInfo<Value> &args) {
-        Isolate *isolate = args.GetIsolate();
-        if (args.Length() < 1) {
-            isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Appkey is required")));
-            return;
-        }
-        String::Utf8Value str(isolate, args[0]);
-
-        CatClientConfig config = DEFAULT_CCAT_CONFIG;
-        config.enableHeartbeat = 0;
-        config.enableMultiprocessing = 1;
-        catClientInitWithConfig((const char *) (*str), &config);
+  /**
+   * Initialize cat
+   * @param args
+   */
+  void Init(const FunctionCallbackInfo<Value> &args)
+  {
+    Isolate *isolate = args.GetIsolate();
+    if (args.Length() < 1)
+    {
+#if (MAJOR_VERSION <= 12)
+      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Appkey is required")));
+#else
+      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Appkey is required").ToLocalChecked()));
+#endif
+      return;
     }
+    String::Utf8Value str(isolate, args[0]);
 
-    /**
-     * Destroy cat
-     * @param args
-     */
-    void Destroy(const FunctionCallbackInfo<Value> &args) {
-        catClientDestroy();
+    CatClientConfig config = DEFAULT_CCAT_CONFIG;
+    config.enableHeartbeat = 0;
+    config.enableMultiprocessing = 1;
+    catClientInitWithConfig((const char *)(*str), &config);
+  }
+
+  /**
+   * Destroy cat
+   * @param args
+   */
+  void Destroy(const FunctionCallbackInfo<Value> &args)
+  {
+    catClientDestroy();
+  }
+
+  void InnerSendNode(Isolate *isolate, Local<Object> node)
+  {
+    if (node->IsNull() || node->IsUndefined())
+    {
+      return;
     }
+    Local<Context> ctx = isolate->GetCurrentContext();
+    cout << NODE_MODULE_VERSION << endl;
+    std::cout << "Value is: " << NODE_MODULE_VERSION << std::endl;
 
-    void InnerSendNode(Isolate *isolate, Local<Object> node) {
-        if (node->IsNull() || node->IsUndefined()) {
-            return;
-        }
-        Local<Context> ctx = isolate->GetCurrentContext();
-        String::Utf8Value messageType(isolate, node->Get(String::NewFromUtf8(isolate, "messageType")));
-        if (strcmp(*messageType, "transaction") == 0) {
-            String::Utf8Value type(isolate, node->Get(String::NewFromUtf8(isolate, "type")));
-            String::Utf8Value name(isolate, node->Get(String::NewFromUtf8(isolate, "name")));
-            String::Utf8Value status(isolate, node->Get(String::NewFromUtf8(isolate, "status")));
-            String::Utf8Value data(isolate, node->Get(String::NewFromUtf8(isolate, "data")));
-            double begin = (node->Get(String::NewFromUtf8(isolate, "beginTimestamp"))->NumberValue(ctx)).ToChecked();
-            double end = (node->Get(String::NewFromUtf8(isolate, "endTimestamp"))->NumberValue(ctx)).ToChecked();
+#if (MAJOR_VERSION <= 12)
+    String::Utf8Value messageType(isolate, node->Get(String::NewFromUtf8(isolate, "messageType")));
+#else
+    v8::Local<v8::String> messageTypeKey = v8::String::NewFromUtf8(isolate, "messageType").ToLocalChecked();
+    v8::Local<v8::Value> messageTypeValue = node->Get(ctx, messageTypeKey).ToLocalChecked();
+    v8::String::Utf8Value messageType(isolate, messageTypeValue);
+#endif
+    if (strcmp(*messageType, "transaction") == 0)
+    {
+#if (MAJOR_VERSION <= 12)
+      String::Utf8Value type(isolate, node->Get(String::NewFromUtf8(isolate, "type")));
+#else
+      v8::Local<v8::String> typeKey = v8::String::NewFromUtf8(isolate, "type").ToLocalChecked();
+      v8::Local<v8::Value> typeValue = node->Get(ctx, typeKey).ToLocalChecked();
+      v8::String::Utf8Value type(isolate, typeValue);
+#endif
 
-            CatTransaction *t = newTransaction((const char *) (*type), (const char *) (*name));
-            t->setDurationInMillis(t, static_cast<unsigned long long int>(end - begin));
-            t->setTimestamp(t, static_cast<unsigned long long int>(begin));
-            t->setStatus(t, (const char *) (*status));
-            t->addData(t, (const char *) (*data));
+#if (MAJOR_VERSION <= 12)
+      String::Utf8Value name(isolate, node->Get(String::NewFromUtf8(isolate, "name")));
+#else
+      v8::Local<v8::String> nameKey = v8::String::NewFromUtf8(isolate, "name").ToLocalChecked();
+      v8::Local<v8::Value> nameValue = node->Get(ctx, nameKey).ToLocalChecked();
+      v8::String::Utf8Value name(isolate, nameValue);
+#endif
 
-            // Iterate children recursively
-            Array *children = Array::Cast((*(node->Get(String::NewFromUtf8(isolate, "children")))));
-            int count = children->Length();
-            for (u_int32_t i = 0; i < count; i++) {
-                InnerSendNode(isolate, Object::Cast((*(children->Get(i))))->Clone());
-            }
+#if (MAJOR_VERSION <= 12)
+      String::Utf8Value status(isolate, node->Get(String::NewFromUtf8(isolate, "status")));
+#else
+      v8::Local<v8::String> statusKey = v8::String::NewFromUtf8(isolate, "status").ToLocalChecked();
+      v8::Local<v8::Value> statusValue = node->Get(ctx, statusKey).ToLocalChecked();
+      v8::String::Utf8Value status(isolate, statusValue);
+#endif
 
-            t->complete(t);
-        } else if (strcmp(*messageType, "event") == 0) {
-            String::Utf8Value type(isolate, node->Get(String::NewFromUtf8(isolate, "type")));
-            String::Utf8Value name(isolate, node->Get(String::NewFromUtf8(isolate, "name")));
-            String::Utf8Value status(isolate, node->Get(String::NewFromUtf8(isolate, "status")));
-            String::Utf8Value data(isolate, node->Get(String::NewFromUtf8(isolate, "data")));
-            double begin(((node->Get(String::NewFromUtf8(isolate, "beginTimestamp")))->NumberValue(ctx)).ToChecked());
+#if (MAJOR_VERSION <= 12)
+      String::Utf8Value data(isolate, node->Get(String::NewFromUtf8(isolate, "data")));
+#else
+      v8::Local<v8::String> dataKey = v8::String::NewFromUtf8(isolate, "data").ToLocalChecked();
+      v8::Local<v8::Value> dataValue = node->Get(ctx, dataKey).ToLocalChecked();
+      v8::String::Utf8Value data(isolate, dataValue);
+#endif
 
-            CatEvent *e = newEvent((const char *) (*type), (const char *) (*name));
-            e->setTimestamp(e, static_cast<unsigned long long int>(begin));
-            e->addData(e, (const char *) (*data));
-            e->setStatus(e, (const char *) (*status));
-            e->complete(e);
-        } else if (strcmp(*messageType, "heartbeat") == 0) {
-            String::Utf8Value type(isolate, node->Get(String::NewFromUtf8(isolate, "type")));
-            String::Utf8Value name(isolate, node->Get(String::NewFromUtf8(isolate, "name")));
-            String::Utf8Value data(isolate, node->Get(String::NewFromUtf8(isolate, "data")));
+#if (MAJOR_VERSION <= 12)
+      double begin = (node->Get(String::NewFromUtf8(isolate, "beginTimestamp"))->NumberValue(ctx)).ToChecked();
+#else
+      v8::Local<v8::String> beginKey = v8::String::NewFromUtf8(isolate, "beginTimestamp").ToLocalChecked();
+      v8::Local<v8::Value> beginValue = node->Get(ctx, beginKey).ToLocalChecked();
+      double begin = beginValue->NumberValue(ctx).ToChecked();
+#endif
 
-            CatHeartBeat *h = newHeartBeat((const char *) (*type), (const char *) (*name));
-            h->addData(h, (const char *) (*data));
-            h->setStatus(h, CAT_SUCCESS);
-            h->complete(h);
-        }
+#if (MAJOR_VERSION <= 12)
+      double end = (node->Get(String::NewFromUtf8(isolate, "endTimestamp"))->NumberValue(ctx)).ToChecked();
+#else
+      v8::Local<v8::String> endKey = v8::String::NewFromUtf8(isolate, "endTimestamp").ToLocalChecked();
+      v8::Local<v8::Value> endValue = node->Get(ctx, endKey).ToLocalChecked();
+      double end = endValue->NumberValue(ctx).ToChecked();
+#endif
+
+      CatTransaction *t = newTransaction((const char *)(*type), (const char *)(*name));
+      t->setDurationInMillis(t, static_cast<unsigned long long int>(end - begin));
+      t->setTimestamp(t, static_cast<unsigned long long int>(begin));
+      t->setStatus(t, (const char *)(*status));
+      t->addData(t, (const char *)(*data));
+
+// Iterate children recursively
+#if (MAJOR_VERSION <= 12)
+      Array *children = Array::Cast((*(node->Get(String::NewFromUtf8(isolate, "children")))));
+#else
+      v8::Local<v8::String> childrenKey = v8::String::NewFromUtf8(isolate, "children").ToLocalChecked();
+      v8::Local<v8::Value> childrenValue = node->Get(ctx, childrenKey).ToLocalChecked();
+      v8::Local<v8::Array> children = v8::Local<v8::Array>::Cast(childrenValue);
+#endif
+
+      int count = children->Length();
+      for (int i = 0; i < count; i++)
+      {
+#if (MAJOR_VERSION <= 12)
+        InnerSendNode(isolate, Object::Cast((*(children->Get(i))))->Clone());
+#else
+        v8::Local<v8::Value> childValue = children->Get(ctx, i).ToLocalChecked();
+        v8::Local<v8::Object> childObject = v8::Local<v8::Object>::Cast(childValue);
+        v8::Local<v8::Object> clonedChildObject = childObject->Clone();
+        InnerSendNode(isolate, clonedChildObject);
+#endif
+      }
+
+      t->complete(t);
     }
+    else if (strcmp(*messageType, "event") == 0)
+    {
+#if (MAJOR_VERSION <= 12)
+      String::Utf8Value type(isolate, node->Get(String::NewFromUtf8(isolate, "type")));
+#else
+      v8::Local<v8::String> typeKey = v8::String::NewFromUtf8(isolate, "type").ToLocalChecked();
+      v8::Local<v8::Value> typeValue = node->Get(ctx, typeKey).ToLocalChecked();
+      v8::String::Utf8Value type(isolate, typeValue);
+#endif
 
-    void SendTree(const FunctionCallbackInfo<Value> &args) {
-        Isolate *isolate = args.GetIsolate();
-        if (args.Length() == 0) {
-            return;
-        }
-        Array *tree = Array::Cast((*args[0]));
+#if (MAJOR_VERSION <= 12)
+      String::Utf8Value name(isolate, node->Get(String::NewFromUtf8(isolate, "name")));
+#else
+      v8::Local<v8::String> nameKey = v8::String::NewFromUtf8(isolate, "name").ToLocalChecked();
+      v8::Local<v8::Value> nameValue = node->Get(ctx, nameKey).ToLocalChecked();
+      v8::String::Utf8Value name(isolate, nameValue);
+#endif
 
-        Array *root = Array::Cast((*(tree->Get(String::NewFromUtf8(isolate, "root")))));
+#if (MAJOR_VERSION <= 12)
+      String::Utf8Value status(isolate, node->Get(String::NewFromUtf8(isolate, "status")));
+#else
+      v8::Local<v8::String> statusKey = v8::String::NewFromUtf8(isolate, "status").ToLocalChecked();
+      v8::Local<v8::Value> statusValue = node->Get(ctx, statusKey).ToLocalChecked();
+      v8::String::Utf8Value status(isolate, statusValue);
+#endif
 
-        InnerSendNode(isolate, root->Clone());
+#if (MAJOR_VERSION <= 12)
+      String::Utf8Value data(isolate, node->Get(String::NewFromUtf8(isolate, "data")));
+#else
+      v8::Local<v8::String> dataKey = v8::String::NewFromUtf8(isolate, "data").ToLocalChecked();
+      v8::Local<v8::Value> dataValue = node->Get(ctx, dataKey).ToLocalChecked();
+      v8::String::Utf8Value data(isolate, dataValue);
+#endif
+
+#if (MAJOR_VERSION <= 12)
+      double begin(((node->Get(String::NewFromUtf8(isolate, "beginTimestamp")))->NumberValue(ctx)).ToChecked());
+#else
+      v8::Local<v8::String> beginKey = v8::String::NewFromUtf8(isolate, "beginTimestamp").ToLocalChecked();
+      v8::Local<v8::Value> beginValue = node->Get(ctx, beginKey).ToLocalChecked();
+      double begin = beginValue->NumberValue(ctx).ToChecked();
+#endif
+
+      CatEvent *e = newEvent((const char *)(*type), (const char *)(*name));
+      e->setTimestamp(e, static_cast<unsigned long long int>(begin));
+      e->addData(e, (const char *)(*data));
+      e->setStatus(e, (const char *)(*status));
+      e->complete(e);
     }
+    else if (strcmp(*messageType, "heartbeat") == 0)
+    {
+#if (MAJOR_VERSION <= 12)
+      String::Utf8Value type(isolate, node->Get(String::NewFromUtf8(isolate, "type")));
+#else
+      v8::Local<v8::String> typeKey = v8::String::NewFromUtf8(isolate, "type").ToLocalChecked();
+      v8::Local<v8::Value> typeValue = node->Get(ctx, typeKey).ToLocalChecked();
+      v8::String::Utf8Value type(isolate, typeValue);
+#endif
 
-    void exports(Local<Object> exports) {
-        NODE_SET_METHOD(exports, "init", Init);
-        NODE_SET_METHOD(exports, "destroy", Destroy);
-        NODE_SET_METHOD(exports, "sendTree", SendTree);
+#if (MAJOR_VERSION <= 12)
+      String::Utf8Value name(isolate, node->Get(String::NewFromUtf8(isolate, "name")));
+#else
+      v8::Local<v8::String> nameKey = v8::String::NewFromUtf8(isolate, "name").ToLocalChecked();
+      v8::Local<v8::Value> nameValue = node->Get(ctx, nameKey).ToLocalChecked();
+      v8::String::Utf8Value name(isolate, nameValue);
+#endif
+
+#if (MAJOR_VERSION <= 12)
+      String::Utf8Value data(isolate, node->Get(String::NewFromUtf8(isolate, "data")));
+#else
+      v8::Local<v8::String> dataKey = v8::String::NewFromUtf8(isolate, "data").ToLocalChecked();
+      v8::Local<v8::Value> dataValue = node->Get(ctx, dataKey).ToLocalChecked();
+      v8::String::Utf8Value data(isolate, dataValue);
+#endif
+
+      CatHeartBeat *h = newHeartBeat((const char *)(*type), (const char *)(*name));
+      h->addData(h, (const char *)(*data));
+      h->setStatus(h, CAT_SUCCESS);
+      h->complete(h);
     }
+  }
 
-    NODE_MODULE(nodecat, exports)
+  void SendTree(const FunctionCallbackInfo<Value> &args)
+  {
+    Isolate *isolate = args.GetIsolate();
+    if (args.Length() == 0)
+    {
+      return;
+    }
+    Array *tree = Array::Cast((*args[0]));
+
+#if (MAJOR_VERSION <= 12)
+    Array *root = Array::Cast((*(tree->Get(String::NewFromUtf8(isolate, "root")))));
+#else
+    Local<Context> ctx = isolate->GetCurrentContext();
+    v8::Local<v8::String> rootKey = v8::String::NewFromUtf8(isolate, "root").ToLocalChecked();
+    v8::Local<v8::Value> rootValue = tree->Get(ctx, rootKey).ToLocalChecked();
+    v8::Local<v8::Array> root = v8::Local<v8::Array>::Cast(rootValue);
+#endif
+
+    InnerSendNode(isolate, root->Clone());
+  }
+
+  void exports(Local<Object> exports)
+  {
+    NODE_SET_METHOD(exports, "init", Init);
+    NODE_SET_METHOD(exports, "destroy", Destroy);
+    NODE_SET_METHOD(exports, "sendTree", SendTree);
+  }
+
+  NODE_MODULE(nodecat, exports)
 
 } // namespace catapi


### PR DESCRIPTION
在nestjs使用中node16+以上版本中使用cat发现编译报错。
后发现社区有类似问题还未解决，参考: https://github.com/dianping/cat/issues/2140
尝试编译官方版本只能支持到node12以内。

问题原因：
项目中使用早期的 V8 API 来操作 JavaScript 对象。
在 Node.js 13 后，由于 V8 的 API 更新，某些早期的方法不再有效或需要调整。

解决方案：
使用条件编译指令对语法进行处理。
