### PR TITLE
Fix a flaky test

### DIFF
--- a/cat-client/src/test/java/com/dianping/cat/message/context/MessageIdFactoryTest.java
+++ b/cat-client/src/test/java/com/dianping/cat/message/context/MessageIdFactoryTest.java
@@ -102,12 +102,16 @@ public class MessageIdFactoryTest extends ComponentTestCase {
 
 		pool.shutdown();
 		pool.awaitTermination(2000, TimeUnit.MILLISECONDS);
+		boolean finished = pool.awaitTermination(1, TimeUnit.HOURS);  
+                if (finished) {
+		        int total = threads * messagesPerThread;
 
-		int total = threads * messagesPerThread;
-
-		Assert.assertEquals("Not all threads completed in time.", total, ids.size());
-		Assert.assertEquals(true, ids.contains(String.format("default-parallel-c0a81f9e-403215-%s", total - 1)));
-		Assert.assertEquals(String.format("default-parallel-c0a81f9e-403215-%s", total), factory.getNextId());
+		        Assert.assertEquals("Not all threads completed in time.", total, ids.size());
+		        Assert.assertEquals(true, ids.contains(String.format("default-parallel-c0a81f9e-403215-%s", total - 1)));
+		        Assert.assertEquals(String.format("default-parallel-c0a81f9e-403215-%s", total), factory.getNextId());
+		} else {
+                         Assert.fail("Threads did not finish in 1 hour");
+		}
 	}
 
 	@Test


### PR DESCRIPTION
This PR is to fix a flaky test `com.dianping.cat.message.context.MessageIdFactoryTest#testDefaultDomainInParallel` in module `cat-client`, we found the problem when using the latest version.

### Reproduce test failures
 - Run the following commands to reproduce the test failures:
```
mvn  edu.illinois:nondex-maven-plugin:2.1.1:nondex  -pl cat-client -Dtest=com.dianping.cat.message.context.MessageIdFactoryTest#testDefaultDomainInParallel
```
- Then we got the following error:
```
MessageIdFactoryTest.testDefaultDomainInParallel:108 Not all threads completed in time. expected:<123400> but was:<12070>
```

### Fix
In order to avoid not all threads not finished before the assertions, the fix is to first wait the jobs to be finished `pool.awaitTermination(1, TimeUnit.HOURS); `, after that if al threads are done, then go to the following assertions.