### PR TITLE
修改maven3.9+版本打包时资源拷贝异常

### DIFF
--- a/cat-home/pom.xml
+++ b/cat-home/pom.xml
@@ -135,7 +135,7 @@
       <resources>
          <resource>
             <directory>${basedir}/src/main/resources</directory>
-            <filtering>true</filtering>
+            <filtering>false</filtering>
          </resource>
       </resources>
       <plugins>


### PR DESCRIPTION
filtering为true 
1、maven3.9.+编译时会出现异常：failed with MalformedInputException: Input length = 1。
2、拷贝文件时会用对文件中的占位符进行替换处理，此处无此需求，改成false更合理。