### PR TITLE
fix: 4.0-RC1 logView parsing + white screen when entering Transaction and other pages

### DIFF
--- a/cat-core/src/main/java/com/dianping/cat/report/service/BaseRemoteModelService.java
+++ b/cat-core/src/main/java/com/dianping/cat/report/service/BaseRemoteModelService.java
@@ -91,9 +91,8 @@ public abstract class BaseRemoteModelService<T> extends ModelServiceWithCalSuppo
 
 			t.addData(url.toString());
 
-			InputStream in = Urls.forIO().connectTimeout(1000).readTimeout(10000).openStream(url.toExternalForm());
-			GZIPInputStream gzip = new GZIPInputStream(in);
-			String xml = Files.forIO().readFrom(gzip, "utf-8");
+			InputStream in = Urls.forIO().connectTimeout(1000).readTimeout(10000).withGzip().openStream(url.toExternalForm());
+			String xml = Files.forIO().readFrom(in, "utf-8");
 
 			int len = xml == null ? 0 : xml.length();
 

--- a/cat-home/src/main/java/com/dianping/cat/report/page/logview/service/LocalMessageService.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/page/logview/service/LocalMessageService.java
@@ -88,7 +88,7 @@ public class LocalMessageService extends LocalModelService<String> implements Mo
 		MessageTree tree = null;
 
 		if (buf != null) {
-			tree = CodecHandler.decode(buf);
+			tree = CodecHandler.decode(changeBuf(buf));
 		}
 
 		if (tree == null) {
@@ -101,7 +101,7 @@ public class LocalMessageService extends LocalModelService<String> implements Mo
 				ByteBuf data = bucket.get(id);
 
 				if (data != null) {
-					tree = CodecHandler.decode(data);
+					tree = CodecHandler.decode(changeBuf(data));
 				}
 			}
 		}
@@ -124,6 +124,17 @@ public class LocalMessageService extends LocalModelService<String> implements Mo
 		}
 
 		return null;
+	}
+
+	private ByteBuf changeBuf(ByteBuf data) {
+		data.markReaderIndex();
+		int length = data.readInt();
+		data.resetReaderIndex();
+		ByteBuf readBytes = data.readBytes(length + 4);
+
+		readBytes.markReaderIndex();
+		readBytes.readInt();
+		return readBytes;
 	}
 
 	public String buildOldReport(ModelRequest request, ModelPeriod period, String domain, ApiPayload payload)

--- a/cat-home/src/main/java/com/dianping/cat/report/page/logview/service/RemoteLogViewService.java
+++ b/cat-home/src/main/java/com/dianping/cat/report/page/logview/service/RemoteLogViewService.java
@@ -59,9 +59,8 @@ public class RemoteLogViewService extends BaseRemoteModelService<String> {
 
 			t.addData(url.toString());
 
-			InputStream in = Urls.forIO().connectTimeout(1000).readTimeout(5000).openStream(url.toExternalForm());
-			GZIPInputStream gzip = new GZIPInputStream(in);
-			String xml = Files.forIO().readFrom(gzip, "utf-8");
+			InputStream in = Urls.forIO().connectTimeout(1000).readTimeout(5000).withGzip().openStream(url.toExternalForm());
+			String xml = Files.forIO().readFrom(in, "utf-8");
 
 			int len = xml == null ? 0 : xml.length();
 


### PR DESCRIPTION
I am using the following platform:
CPU: Apple M3 Pro
OS: macOS Sonoma 14.4.1
JDK: 1.8.0_241

After deploying with the default master branch, issues such as a blank screen and an empty Logview were encountered. Debugging revealed that the blank screen was caused by problems with gzip-compressed data, while the Logview issue occurred due to changes in binary parsing rules. For reference, see #2309 . A thorough fix was implemented, thanks to the solution provided by @lxil520.

master:
![cat-01](https://github.com/user-attachments/assets/2919a97c-0767-4347-93e1-33c6360a3f3b)

after:
![cat-02](https://github.com/user-attachments/assets/1346f41e-feff-4723-a471-e9c159402b26)

![cat-03](https://github.com/user-attachments/assets/022b6a57-c1c5-4276-b1f6-4922b8616df3)

本人使用平台：
CPU：Apple M3 Pro
OS: MacOS Sonoma 14.4.1
JDK: 1.8.0_241

使用默认的master分支部署后，出现了白屏以及Logview为空的问题。白屏的问题经过debug发现是gzip压缩数据的问题，logView不展示是因为二进制解析规则变更，参考[#issue2309](https://github.com/dianping/cat/issues/2309)
于是做了一次集中修复，感谢@lxil520 提供的修复方案。

master分支：
![cat-01](https://github.com/user-attachments/assets/2919a97c-0767-4347-93e1-33c6360a3f3b)

修改后：
![cat-02](https://github.com/user-attachments/assets/1346f41e-feff-4723-a471-e9c159402b26)

![cat-03](https://github.com/user-attachments/assets/022b6a57-c1c5-4276-b1f6-4922b8616df3)

