### PR TITLE
fix: 修复README中失效的Star历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ git clone --depth=1 https://github.com/dianping/cat.git
 
 ### Starred 趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dianping/cat&type=Date)](https://star-history.com/#dianping/cat&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dianping/cat&type=Date)](https://star-history.dera.page/#dianping/cat&type=Date)


### PR DESCRIPTION
README中的Star历史图表当前已经失效：GitHub已将stargazer API限制为仅仓库所有者可用，原star-history服务因此无法正常工作。本PR将图表及其链接指向可用的镜像 star-history.dera.page，无需任何API token即可正常展示。

修改仅涉及README.md中的图表链接，不影响其他内容。